### PR TITLE
Overhauled error handling.

### DIFF
--- a/src/blend.rs
+++ b/src/blend.rs
@@ -12,10 +12,11 @@ extern crate image;
 
 
 // from local crate
+use error::RasterResult;
 use Image;
 use Color;
 
-pub fn difference(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, loop_start_x:i32, loop_end_x:i32, offset_x:i32, offset_y:i32, opacity:f32) -> Result<Image, String> {
+pub fn difference(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, loop_start_x:i32, loop_end_x:i32, offset_x:i32, offset_y:i32, opacity:f32) -> RasterResult<Image> {
 
     let mut canvas = image1.clone();
 
@@ -28,26 +29,26 @@ pub fn difference(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i
             let r1 = rgba1.r as f32 * a1;
             let g1 = rgba1.g as f32 * a1;
             let b1 = rgba1.b as f32 * a1;
-            
+
             let rgba2 = try!(image2.get_pixel(x, y));
             let a2 = rgba2.a as f32 / 255.0 * opacity; // convert to 0.0 - 1.0
             let r2 = rgba2.r as f32;
             let g2 = rgba2.g as f32;
             let b2 = rgba2.b as f32;
-            
+
             let r3 = ch_alpha_f(r1, r2, "difference", a2);
             let g3 = ch_alpha_f(g1, g2, "difference", a2);
             let b3 = ch_alpha_f(b1, b2, "difference", a2);
             let a3 = 255;
-            
+
             try!(canvas.set_pixel(canvas_x, canvas_y, Color::rgba(r3 as u8, g3 as u8, b3 as u8, a3 as u8)));
         }
     }
-    
+
     Ok(canvas)
 }
 
-pub fn multiply(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, loop_start_x:i32, loop_end_x:i32, offset_x:i32, offset_y:i32, opacity:f32) -> Result<Image, String> {
+pub fn multiply(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, loop_start_x:i32, loop_end_x:i32, offset_x:i32, offset_y:i32, opacity:f32) -> RasterResult<Image> {
 
     let mut canvas = image1.clone();
 
@@ -60,26 +61,26 @@ pub fn multiply(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32
             let r1 = rgba1.r as f32 * a1;
             let g1 = rgba1.g as f32 * a1;
             let b1 = rgba1.b as f32 * a1;
-            
+
             let rgba2 = try!(image2.get_pixel(x, y));
             let a2 = rgba2.a as f32 / 255.0 * opacity; // convert to 0.0 - 1.0
             let r2 = rgba2.r as f32;
             let g2 = rgba2.g as f32;
             let b2 = rgba2.b as f32;
-            
+
             let r3 = ch_alpha_f(r1, r2, "multiply", a2);
             let g3 = ch_alpha_f(g1, g2, "multiply", a2);
             let b3 = ch_alpha_f(b1, b2, "multiply", a2);
             let a3 = 255;
-            
+
             try!(canvas.set_pixel(canvas_x, canvas_y, Color::rgba(r3 as u8, g3 as u8, b3 as u8, a3 as u8)));
         }
     }
-    
+
     Ok(canvas)
 }
 
-pub fn normal(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, loop_start_x:i32, loop_end_x:i32, offset_x:i32, offset_y:i32, opacity:f32) -> Result<Image, String> {
+pub fn normal(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, loop_start_x:i32, loop_end_x:i32, offset_x:i32, offset_y:i32, opacity:f32) -> RasterResult<Image> {
 
     let mut canvas = image1.clone();
 
@@ -92,26 +93,26 @@ pub fn normal(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, 
             let r1 = color1.r as f32 * a1;
             let g1 = color1.g as f32 * a1;
             let b1 = color1.b as f32 * a1;
-            
+
             let color2 = try!(image2.get_pixel(x, y));
             let a2 = color2.a as f32 / 255.0 * opacity; // convert to 0.0 - 1.0
             let r2 = color2.r as f32;
             let g2 = color2.g as f32;
             let b2 = color2.b as f32;
-            
+
             let r3 = (a2 * r2) + ((1.0 - a2) * r1);
             let g3 = (a2 * g2) + ((1.0 - a2) * g1);
             let b3 = (a2 * b2) + ((1.0 - a2) * b1);
             let a3 = 255;
-            
+
             try!(canvas.set_pixel(canvas_x, canvas_y, Color::rgba(r3 as u8, g3 as u8, b3 as u8, a3 as u8)));
         }
     }
-    
+
     Ok(canvas)
 }
 
-pub fn overlay(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, loop_start_x:i32, loop_end_x:i32, offset_x:i32, offset_y:i32, opacity:f32) -> Result<Image, String> {
+pub fn overlay(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, loop_start_x:i32, loop_end_x:i32, offset_x:i32, offset_y:i32, opacity:f32) -> RasterResult<Image> {
 
     let mut canvas = image1.clone();
 
@@ -124,13 +125,13 @@ pub fn overlay(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32,
             let r1 = rgba1.r as f32 * a1;
             let g1 = rgba1.g as f32 * a1;
             let b1 = rgba1.b as f32 * a1;
-            
+
             let rgba2 = try!(image2.get_pixel(x, y));
             let a2 = rgba2.a as f32 / 255.0 * opacity; // convert to 0.0 - 1.0
             let r2 = rgba2.r as f32;
             let g2 = rgba2.g as f32;
             let b2 = rgba2.b as f32;
-            
+
             let r3 = ch_alpha_f(r1, r2, "overlay", a2);
             let g3 = ch_alpha_f(g1, g2, "overlay", a2);
             let b3 = ch_alpha_f(b1, b2, "overlay", a2);
@@ -139,11 +140,11 @@ pub fn overlay(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32,
             try!(canvas.set_pixel(canvas_x, canvas_y, Color::rgba(r3 as u8, g3 as u8, b3 as u8, a3 as u8)));
         }
     }
-    
+
     Ok(canvas)
 }
 
-pub fn screen(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, loop_start_x:i32, loop_end_x:i32, offset_x:i32, offset_y:i32, opacity:f32) -> Result<Image, String> {
+pub fn screen(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, loop_start_x:i32, loop_end_x:i32, offset_x:i32, offset_y:i32, opacity:f32) -> RasterResult<Image> {
 
     let mut canvas = image1.clone();
 
@@ -156,13 +157,13 @@ pub fn screen(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, 
             let r1 = rgba1.r as f32 * a1;
             let g1 = rgba1.g as f32 * a1;
             let b1 = rgba1.b as f32 * a1;
-            
+
             let rgba2 = try!(image2.get_pixel(x, y));
             let a2 = rgba2.a as f32 / 255.0 * opacity; // convert to 0.0 - 1.0
             let r2 = rgba2.r as f32;
             let g2 = rgba2.g as f32;
             let b2 = rgba2.b as f32;
-            
+
             let r3 = ch_alpha_f(r1, r2, "screen", a2);
             let g3 = ch_alpha_f(g1, g2, "screen", a2);
             let b3 = ch_alpha_f(b1, b2, "screen", a2);
@@ -171,12 +172,12 @@ pub fn screen(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, 
             try!(canvas.set_pixel(canvas_x, canvas_y, Color::rgba(r3 as u8, g3 as u8, b3 as u8, a3 as u8)));
         }
     }
-    
+
     Ok(canvas)
 }
 
 // PRIVATE FNs
-// base, top 0.0 - 255.0  
+// base, top 0.0 - 255.0
 // opacity 0.0 - 1.0
 
 fn ch_alpha_f(base: f32, top: f32, f: &str, opacity: f32) -> f32 {
@@ -212,4 +213,3 @@ fn ch_overlay(base: f32, top: f32) -> f32 {
 fn ch_screen(base: f32, top:f32) -> f32 {
     255.0 - (((255.0 - base) * (255.0 - top)) / 255.0)
 }
-

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -7,24 +7,25 @@
 // from external crate
 
 // from local crate
+use error::RasterResult;
 use Image;
 use editor;
 
-/// Compare two images and returns a hamming distance. A value of 0 indicates a likely similar picture. 
+/// Compare two images and returns a hamming distance. A value of 0 indicates a likely similar picture.
 /// A value between 1 and 10 is potentially a variation. A value greater than 10 is likely a different image.
 ///
 /// # Examples
 /// ```
 /// use raster::compare;
-/// 
+///
 /// let image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let image2 = raster::open("tests/in/sample.png").unwrap();
-/// 
+///
 /// let hamming_distance = compare::similar(&image1, &image2).unwrap();
 /// println!("{}", hamming_distance);
 /// ```
-pub fn similar(image1: &Image, image2: &Image) -> Result<u8, String> {
-    
+pub fn similar(image1: &Image, image2: &Image) -> RasterResult<u8> {
+
     let bin1 = try!(diff_hash(image1));
     let bin2 = try!(diff_hash(image2));
     let mut distance = 0;
@@ -36,21 +37,21 @@ pub fn similar(image1: &Image, image2: &Image) -> Result<u8, String> {
     Ok(distance)
 }
 
-/// Compare if two images are equal. It will compare if the two images are of the same width and height. 
-/// If the dimensions differ, it will return false. If the dimensions are equal, it will loop through each pixels. 
+/// Compare if two images are equal. It will compare if the two images are of the same width and height.
+/// If the dimensions differ, it will return false. If the dimensions are equal, it will loop through each pixels.
 /// If one of the pixel don't match, it will return false. The pixels are compared using their RGB (Red, Green, Blue) values.
 ///
 /// # Examples
 /// ```
 /// use raster::compare;
-/// 
+///
 /// let image1 = raster::open("tests/in/sample.png").unwrap();
 /// let image2 = raster::open("tests/in/sample.png").unwrap();
-/// 
+///
 /// let equal = compare::equal(&image1, &image2).unwrap();
 /// assert_eq!(true, equal);
 /// ```
-pub fn equal(image1: &Image, image2: &Image)-> Result<bool, String> {
+pub fn equal(image1: &Image, image2: &Image)-> RasterResult<bool> {
 
     // Check if image dimensions are equal
     if image1.width != image2.width || image1.height != image2.height {
@@ -70,7 +71,7 @@ pub fn equal(image1: &Image, image2: &Image)-> Result<bool, String> {
                 let pixel2 = try!(image2.get_pixel(x, y));
 
                 // Compare pixel value
-                if 
+                if
                     pixel1.r != pixel2.r ||
                     pixel1.g != pixel2.g ||
                     pixel1.b != pixel2.b
@@ -97,7 +98,7 @@ pub fn equal(image1: &Image, image2: &Image)-> Result<bool, String> {
 // http://www.hackerfactor.com/blog/index.php?/archives/529-Kind-of-Like-That.html
 //
 //
-fn diff_hash(image: &Image) -> Result<Vec<u8>, String> {
+fn diff_hash(image: &Image) -> RasterResult<Vec<u8>> {
 
     let width  = 9;
     let height = 8;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -42,6 +42,10 @@ use transform;
 ///
 /// The offset_x and offset_y are added to the final position. Can also be negative offsets.
 ///
+/// # Errors
+///
+/// If image2 falls outside the canvas area, then this fails with `RasterError::BlendingImageFallsOutsideCanvas`.
+///
 /// # Examples
 /// ```
 /// use raster::editor;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -9,15 +9,16 @@ extern crate image;
 
 
 // from local crate
+use error::{RasterError, RasterResult};
 use blend;
 use Color;
 use Image;
 use position::Position;
 use transform;
 
-/// Blend 2 images into one. The image1 is the base and image2 is the top. 
-/// 
-/// Supported blend modes: 
+/// Blend 2 images into one. The image1 is the base and image2 is the top.
+///
+/// Supported blend modes:
 ///
 /// * normal
 /// * difference
@@ -25,7 +26,7 @@ use transform;
 /// * overlay
 /// * screen
 ///
-/// Possible position: 
+/// Possible position:
 ///
 /// * top-left
 /// * top-center
@@ -48,7 +49,7 @@ use transform;
 /// // Create images from file
 /// let image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let image2 = raster::open("tests/in/watermark.png").unwrap();
-/// 
+///
 /// // Blend image2 on top of image1 using normal mode, opacity of 1.0 (100%), with image2 at the center, with 0 x and 0 y offsets. whew
 /// let normal = editor::blend(&image1, &image2, "normal", 1.0, "center", 0, 0).unwrap();
 ///
@@ -67,16 +68,16 @@ use transform;
 /// ```
 /// ### Source Images
 ///
-/// Image 1 
+/// Image 1
 ///
 /// ![](https://kosinix.github.io/raster/in/sample.jpg)
 ///
 /// Image 2
 ///
 /// ![](https://kosinix.github.io/raster/in/watermark.png)
-/// 
+///
 /// ### Blended Images
-/// 
+///
 /// Normal
 ///
 /// ![](https://kosinix.github.io/raster/out/test_blend_normal.png)
@@ -85,23 +86,23 @@ use transform;
 ///
 /// ![](https://kosinix.github.io/raster/out/test_blend_difference.png)
 ///
-/// 
+///
 /// Multiply
 ///
 /// ![](https://kosinix.github.io/raster/out/test_blend_multiply.png)
 ///
-/// 
+///
 /// Overlay
 ///
 /// ![](https://kosinix.github.io/raster/out/test_blend_overlay.png)
 ///
-/// 
+///
 /// Screen
 ///
 /// ![](https://kosinix.github.io/raster/out/test_blend_screen.png)
 ///
-pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: &str, opacity: f32, position: &str, offset_x: i32, offset_y: i32) -> Result<Image, String> {
-    
+pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: &str, opacity: f32, position: &str, offset_x: i32, offset_y: i32) -> RasterResult<Image> {
+
     let mut opacity = opacity;
     if opacity > 1.0 {
         opacity = 1.0
@@ -124,7 +125,7 @@ pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: &str, opacity: f32,
         (offset_y >= h1) ||
         (offset_y + h2 <= 0) {
 
-        return Err("Invalid blending. Image 2 is outside the canvas.".to_string());
+        return Err(RasterError::BlendingImageFallsOutsideCanvas);
     }
 
     // Loop start X
@@ -182,14 +183,14 @@ pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: &str, opacity: f32,
             Ok(image3)
         },
         _ => {
-            Err(format!("Invalid blend type {}.", &*blend_mode))
+            Err(RasterError::InvalidBlendMode(blend_mode))
         }
     }
 }
 
 /// Crop the image to the given dimension and position.
 ///
-/// Possible position: 
+/// Possible position:
 ///
 /// * top-left
 /// * top-center
@@ -261,15 +262,15 @@ pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: &str, opacity: f32,
 ///
 /// ![](https://kosinix.github.io/raster/out/test_crop_top_left.jpg)
 /// ![](https://kosinix.github.io/raster/out/test_crop_top_center.jpg)
-/// ![](https://kosinix.github.io/raster/out/test_crop_top_right.jpg)  
+/// ![](https://kosinix.github.io/raster/out/test_crop_top_right.jpg)
 /// ![](https://kosinix.github.io/raster/out/test_crop_center_left.jpg)
 /// ![](https://kosinix.github.io/raster/out/test_crop_center.jpg)
-/// ![](https://kosinix.github.io/raster/out/test_crop_center_right.jpg)  
+/// ![](https://kosinix.github.io/raster/out/test_crop_center_right.jpg)
 /// ![](https://kosinix.github.io/raster/out/test_crop_bottom_left.jpg)
 /// ![](https://kosinix.github.io/raster/out/test_crop_bottom_center.jpg)
 /// ![](https://kosinix.github.io/raster/out/test_crop_bottom_right.jpg)
 ///
-pub fn crop<'a>(mut src: &'a mut Image, crop_width: i32, crop_height: i32, position: &str, offset_x: i32, offset_y: i32) -> Result<(), String> {
+pub fn crop<'a>(mut src: &'a mut Image, crop_width: i32, crop_height: i32, position: &str, offset_x: i32, offset_y: i32) -> RasterResult<()> {
 
     // Turn into positioner struct
     let positioner = Position::new(position, offset_x, offset_y);
@@ -280,13 +281,13 @@ pub fn crop<'a>(mut src: &'a mut Image, crop_width: i32, crop_height: i32, posit
 
 
     let mut height2 = offset_y + crop_height;
-    if height2 > src.height { 
-        height2 = src.height 
+    if height2 > src.height {
+        height2 = src.height
     }
 
     let mut width2 = offset_x + crop_width;
-    if width2 > src.width { 
-        width2 = src.width 
+    if width2 > src.width {
+        width2 = src.width
     }
 
     let mut dest = Image::blank(width2-offset_x, height2-offset_y);
@@ -300,7 +301,7 @@ pub fn crop<'a>(mut src: &'a mut Image, crop_width: i32, crop_height: i32, posit
     src.width = dest.width;
     src.height = dest.height;
     src.bytes = dest.bytes;
-    
+
     Ok(())
 }
 
@@ -321,9 +322,9 @@ pub fn crop<'a>(mut src: &'a mut Image, crop_width: i32, crop_height: i32, posit
 /// // Save it
 /// raster::save(&image, "tests/out/test_fill.png");
 /// ```
-/// 
 ///
-pub fn fill(mut src: &mut Image, color: Color) -> Result<(), String> {
+///
+pub fn fill(mut src: &mut Image, color: Color) -> RasterResult<()> {
 
     for y in 0..src.height {
         for x in 0..src.width {
@@ -338,7 +339,7 @@ pub fn fill(mut src: &mut Image, color: Color) -> Result<(), String> {
 ///
 /// Modes:
 ///
-/// * exact - Resize image to exact dimensions ignoring aspect ratio. 
+/// * exact - Resize image to exact dimensions ignoring aspect ratio.
 /// * exact_width - Resize image to exact width. Height parameter is ignored and is auto calculated instead.
 /// * exact_height - Resize image to exact height. Width parameter is ignored and is auto calculated instead.
 /// * fit - Resize an image to fit within the given width and height.
@@ -354,7 +355,7 @@ pub fn fill(mut src: &mut Image, color: Color) -> Result<(), String> {
 /// // Create an image from file
 /// let mut image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let mut image2 = raster::open("tests/in/portrait.jpg").unwrap();
-/// 
+///
 /// // Resize it
 /// editor::resize(&mut image1, 200, 200, "fit");
 /// editor::resize(&mut image2, 200, 200, "fit");
@@ -383,7 +384,7 @@ pub fn fill(mut src: &mut Image, color: Color) -> Result<(), String> {
 /// // Create an image from file
 /// let mut image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let mut image2 = raster::open("tests/in/portrait.jpg").unwrap();
-/// 
+///
 /// // Resize it
 /// editor::resize(&mut image1, 200, 200, "fill");
 /// editor::resize(&mut image2, 200, 200, "fill");
@@ -405,7 +406,7 @@ pub fn fill(mut src: &mut Image, color: Color) -> Result<(), String> {
 /// // Create an image from file
 /// let mut image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let mut image2 = raster::open("tests/in/portrait.jpg").unwrap();
-/// 
+///
 /// // Resize it
 /// editor::resize(&mut image1, 200, 200, "exact_width");
 /// editor::resize(&mut image2, 200, 200, "exact_width");
@@ -416,7 +417,7 @@ pub fn fill(mut src: &mut Image, color: Color) -> Result<(), String> {
 ///
 /// The images will have a width of 200. The height is auto-calculated.
 ///
-/// ![](https://kosinix.github.io/raster/out/test_resize_exact_width_1.jpg)  
+/// ![](https://kosinix.github.io/raster/out/test_resize_exact_width_1.jpg)
 /// ![](https://kosinix.github.io/raster/out/test_resize_exact_width_2.jpg)
 ///
 /// ### Resize to Exact Height
@@ -428,7 +429,7 @@ pub fn fill(mut src: &mut Image, color: Color) -> Result<(), String> {
 /// // Create an image from file
 /// let mut image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let mut image2 = raster::open("tests/in/portrait.jpg").unwrap();
-/// 
+///
 /// // Resize it
 /// editor::resize(&mut image1, 200, 200, "exact_height");
 /// editor::resize(&mut image2, 200, 200, "exact_height");
@@ -450,7 +451,7 @@ pub fn fill(mut src: &mut Image, color: Color) -> Result<(), String> {
 /// // Create an image from file
 /// let mut image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let mut image2 = raster::open("tests/in/portrait.jpg").unwrap();
-/// 
+///
 /// // Resize it
 /// editor::resize(&mut image1, 200, 200, "exact");
 /// editor::resize(&mut image2, 200, 200, "exact");
@@ -463,31 +464,13 @@ pub fn fill(mut src: &mut Image, color: Color) -> Result<(), String> {
 ///
 /// ![](https://kosinix.github.io/raster/out/test_resize_exact_1.jpg) ![](https://kosinix.github.io/raster/out/test_resize_exact_2.jpg)
 ///
-pub fn resize<'a>(mut src: &'a mut Image, w: i32, h: i32, mode: &str) -> Result<(), String> {
-    
+pub fn resize<'a>(mut src: &'a mut Image, w: i32, h: i32, mode: &str) -> RasterResult<()> {
     match mode {
-        "exact" => {
-            try!(transform::resize_exact(&mut src, w, h));
-            Ok(())
-        }
-        "exact_width" => {
-            try!(transform::resize_exact_width(&mut src, w));
-            Ok(())
-        }
-        "exact_height" => {
-            try!(transform::resize_exact_height(&mut src, h));
-            Ok(())
-        }
-        "fit" => {
-            try!(transform::resize_fit(&mut src, w, h));
-            Ok(())
-        },
-        "fill" => {
-            try!(transform::resize_fill(&mut src, w, h));
-            Ok(())
-        },
-        _ => {
-            Err(format!("Invalid resize mode '{}'.", mode))
-        },
-    }
+        "exact" => transform::resize_exact(&mut src, w, h),
+        "exact_width" => transform::resize_exact_width(&mut src, w),
+        "exact_height" => transform::resize_exact_height(&mut src, h),
+        "fit" => transform::resize_fit(&mut src, w, h),
+        "fill" => transform::resize_fill(&mut src, w, h),
+        _ => Err(RasterError::InvalidResiveMode(mode.to_string()))
+    }.map(|_| ())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,33 @@
+use std::io::Error as IoError;
+use std::num::ParseIntError;
+use image::ImageError;
+
+#[derive(Debug)]
+pub enum RasterError {
+    Io(IoError),
+    PixelOutOfBounds(i32, i32),
+    InvalidStartIndex(i32),
+    InvalidHex,
+    HexParse(ParseIntError),
+    BlendingImageFallsOutsideCanvas,
+    InvalidGamma(f32),
+
+    /*
+    In an ideal world, image's error type needn't be exposed
+    (but we don't live in an ideal world yet)
+    */
+    Image(ImageError),
+
+    /*
+    All of these invalid mode/type errors will be unneeded once mode/type flags are switched
+    to using enums rather than strings.
+    */
+    InvalidBlendMode(String),
+    InvalidResiveMode(String),
+    InvalidBlurMode(String),
+    InvalidInterpolationMode(String),
+    InvalidTransformMode(String),
+    InvalidPositionType(String)
+}
+
+pub type RasterResult<T> = Result<T, RasterError>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+//!  A module for error types.
+
 use std::io::Error as IoError;
 use std::num::ParseIntError;
 use image::ImageError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! Raster is an image processing lib for Rust.
 //!
 //! It provides a simplified API for processing raster images (JPEG, PNG and GIF).
-//! 
+//!
 //! ## Installation
 //! Add this to your Cargo.toml file:
 //!
@@ -33,12 +33,12 @@
 //! ### Create a blank image
 //! ```rust,ignore
 //! use raster::Image; // Include the Image struct
-//! 
+//!
 //! // Create a blank 150x100 image. Defaults to a black background.
 //! let image = Image::blank(150, 100);
 //!
 //! ```
-//! 
+//!
 //! ## Saving Images
 //! Save the opened image file:
 //!
@@ -50,14 +50,14 @@
 //! raster::save(&image, "tests/out/test_open_save.png");
 //!
 //! ```
-//! 
+//!
 //!
 //!
 //!
 //! ## Blending 2 Images
 //!
 //! Here are two images blended using the normal mode.
-//! 
+//!
 //! ![](https://kosinix.github.io/raster/out/test_blend_normal.png)
 //!
 //! More blending modes and options are available, see the blend API.
@@ -74,13 +74,14 @@
 //!
 //! Images can be rotated both clockwise and counter-clockwise at any arbitrary angle with a custom background color.
 //!
-//! ![](https://kosinix.github.io/raster/out/test_transform_rotate_45.png)  
+//! ![](https://kosinix.github.io/raster/out/test_transform_rotate_45.png)
 //! ![](https://kosinix.github.io/raster/out/test_transform_rotate_45cc.png)
 //!
 //! ## And Many More...
 //!
 //! More options are available, checkout the modules below.
 //!
+pub mod error;
 pub mod compare;
 pub mod editor;
 pub mod filter;
@@ -100,20 +101,20 @@ use std::collections::HashMap;
 use self::image::GenericImage;
 
 // from local crate
-
+use error::{RasterError, RasterResult};
 
 /// Create an image from an image file.
 ///
 /// # Examples
-/// 
+///
 /// ```
 /// // Create an image from file
 /// let image = raster::open("tests/in/sample.png").unwrap();
 /// println!("{:?}", image.bytes);
 /// ```
-pub fn open(image_file: &str) -> Result<Image, String> {
-    
-    let src = image::open(image_file).unwrap(); // Returns image::DynamicImage
+pub fn open(image_file: &str) -> RasterResult<Image> {
+
+    let src = try!(image::open(image_file).map_err(RasterError::Image)); // Returns image::DynamicImage
     let (w, h) = src.dimensions();
     let mut bytes = Vec::new();
     for y in 0..h {
@@ -125,7 +126,7 @@ pub fn open(image_file: &str) -> Result<Image, String> {
             bytes.push(p.data[3]);
         }
     }
-    Ok(Image{ 
+    Ok(Image{
         width: w as i32,
         height: h as i32,
         bytes: bytes
@@ -136,16 +137,20 @@ pub fn open(image_file: &str) -> Result<Image, String> {
 /// Save an image to an image file. The image type is detected from the file extension of the file name.
 ///
 /// # Examples
-/// 
+///
 /// ```
 /// // Create an image from file
 /// let image = raster::open("tests/in/sample.png").unwrap();
 /// raster::save(&image, "tests/out/test.png");
 /// ```
-pub fn save(image: &Image, out: &str) {
-    
-    image::save_buffer(&Path::new(out), &image.bytes, image.width as u32, image.height as u32, image::RGBA(8)).unwrap();
-
+pub fn save(image: &Image, out: &str) -> RasterResult<()> {
+    image::save_buffer(
+        &Path::new(out),
+        &image.bytes,
+        image.width as u32,
+        image.height as u32,
+        image::RGBA(8)
+    ).map_err(RasterError::Io)
 }
 
 /// A struct for easily representing a raster image.
@@ -153,16 +158,16 @@ pub fn save(image: &Image, out: &str) {
 pub struct Image {
     /// Width of image in pixels.
     pub width: i32, //  i32 type is used as computation with negative integers is common.
-    
+
     /// Height of image in pixels.
-    pub height: i32,    
+    pub height: i32,
 
     /// Vector containing sequence of bytes in RGBA format.
     pub bytes: Vec<u8>,
 }
 
 impl<'a> Image {
-    
+
     /// Create a blank image. Default color is black.
     ///
     /// # Examples
@@ -171,14 +176,14 @@ impl<'a> Image {
     /// use raster::Image;
     ///
     /// let image = Image::blank(2, 2);
-    /// 
+    ///
     /// println!("{:?}", image.bytes);
     ///
     /// assert_eq!(image.width, 2);
     /// assert_eq!(image.height, 2);
     /// ```
     pub fn blank(w:i32, h:i32) -> Image {
-        
+
         let mut bytes = Vec::new();
         for _ in 0..h {
             for _ in 0..w {
@@ -188,7 +193,7 @@ impl<'a> Image {
                 bytes.push(255);
             }
         }
-        Image { 
+        Image {
             width: w,
             height: h,
             bytes: bytes
@@ -203,12 +208,12 @@ impl<'a> Image {
     /// use raster::Image;
     ///
     /// let image = Image::blank(2, 2);
-    /// 
+    ///
     /// assert_eq!(image.check_pixel(0, 0), true);
     /// assert_eq!(image.check_pixel(3, 3), false);
     /// ```
     pub fn check_pixel(&self, x: i32, y:i32) -> bool {
-        
+
         if y < 0 || y > self.height { // TODO: check on actual vectors and not just width and height?
             return false;
 
@@ -254,9 +259,9 @@ impl<'a> Image {
     /// use raster::Color;
     ///
     /// let image = raster::open("tests/in/sample.png").unwrap();
-    /// 
+    ///
     /// let (r_bin, _, _, _) = image.histogram().unwrap();
-    /// 
+    ///
     /// let mut max_r_bin = 0;
     /// for (_, count) in &r_bin {
     ///     if *count > max_r_bin {
@@ -268,18 +273,18 @@ impl<'a> Image {
     /// let canvas_h: i32 = 100;
     /// let mut image = Image::blank(canvas_w, canvas_h);
     /// raster::editor::fill(&mut image, Color::rgb(214, 214, 214)).unwrap();
-    /// 
+    ///
     /// for x in 0..256 as i32 { // 0-255
     ///     let key = x as u8;
     ///     match r_bin.get(&key) {
     ///         Some(count) => {
-    /// 
+    ///
     ///             let height = (canvas_h as f32 * (*count as f32 / max_r_bin as f32)).round() as i32;
-    /// 
+    ///
     ///             for y in canvas_h-height..canvas_h {
-    /// 
+    ///
     ///                 image.set_pixel(x, y, Color::hex("#e22d11").unwrap()).unwrap();
-    ///                 
+    ///
     ///             }
     ///         },
     ///         None => {}
@@ -294,10 +299,10 @@ impl<'a> Image {
     /// ![](https://kosinix.github.io/raster/out/histogram.png)
     ///
     /// Photoshop's result:
-    /// 
+    ///
     /// ![](https://kosinix.github.io/raster/in/histogram-ps.png)
     ///
-    pub fn histogram(&self) -> Result< (HashMap<u8, u32>, HashMap<u8, u32>, HashMap<u8, u32>, HashMap<u8, u32>), String> {
+    pub fn histogram(&self) -> RasterResult<(HashMap<u8, u32>, HashMap<u8, u32>, HashMap<u8, u32>, HashMap<u8, u32>)> {
         let w = self.width;
         let h = self.height;
 
@@ -344,7 +349,7 @@ impl<'a> Image {
     /// assert_eq!(0, pixel.b);
     /// assert_eq!(255, pixel.a);
     /// ```
-    pub fn get_pixel(&self, x: i32, y:i32) -> Result<Color, String> {
+    pub fn get_pixel(&self, x: i32, y:i32) -> RasterResult<Color> {
         let rgba = 4;
         let start = (y * &self.width) + x;
         let start = start * rgba;
@@ -352,16 +357,16 @@ impl<'a> Image {
         let len = self.bytes.len();
 
         if start as usize > len || end as usize > len {
-            return Err(format!("Getting a pixel at ({}, {}) that is out of bounds.", x, y).to_string());
+            Err(RasterError::PixelOutOfBounds(x, y))
+        } else {
+            let slice = &self.bytes[start as usize..end as usize];
+            Ok(Color {
+                r: slice[0],
+                g: slice[1],
+                b: slice[2],
+                a: slice[3],
+            })
         }
-        
-        let slice = &self.bytes[start as usize..end as usize];
-        Ok(Color {
-            r: slice[0],
-            g: slice[1],
-            b: slice[2],
-            a: slice[3],
-        })
     }
 
     /// Set pixel in a given x and y location of an image.
@@ -383,24 +388,23 @@ impl<'a> Image {
     /// assert_eq!(0, pixel.b);
     /// assert_eq!(255, pixel.a);
     /// ```
-    pub fn set_pixel(&mut self, x: i32, y:i32, color: Color ) -> Result<(), String> {
+    pub fn set_pixel(&mut self, x: i32, y:i32, color: Color ) -> RasterResult<()> {
         let rgba = 4; // length
         let start = (y * &self.width) + x;
         let start = start * rgba;
-        
-        if x >= self.width || y >= self.height {
-            return Err(format!("Setting a pixel that is out of bounds at ({}, {}).", x, y).to_string());
-        }
-        if start < 0 {
-            return Err(format!("Invalid start index {}.", start).to_string());
-        }
-        
-        self.bytes[start as usize] = color.r;
-        self.bytes[start as usize + 1] = color.g;
-        self.bytes[start as usize + 2] = color.b;
-        self.bytes[start as usize + 3] = color.a;
 
-        Ok(())
+        if x >= self.width || y >= self.height {
+            Err(RasterError::PixelOutOfBounds(x, y))
+        } else if start < 0 {
+            Err(RasterError::InvalidStartIndex(start))
+        } else {
+            self.bytes[start as usize] = color.r;
+            self.bytes[start as usize + 1] = color.g;
+            self.bytes[start as usize + 2] = color.b;
+            self.bytes[start as usize + 3] = color.a;
+
+            Ok(())
+        }
     }
 }
 
@@ -411,7 +415,7 @@ impl<'a> Image {
 pub struct Color {
     /// Red channel 0 - 255
     pub r: u8,
-    
+
     /// Green channel 0 - 255
     pub g: u8,
 
@@ -423,7 +427,7 @@ pub struct Color {
 }
 
 impl<'a> Color {
-    
+
     /// Returns a black Color.
     pub fn black() -> Color {
         Color {
@@ -475,17 +479,17 @@ impl<'a> Color {
     /// // Ok tests
     /// let color = Color::hex("#FFFFFF"); // Opaque white
     /// assert!(color.is_ok());
-    /// 
+    ///
     /// let color = Color::hex("#00FF007F"); // Green with 50% opacity
     /// assert!(color.is_ok());
-    /// 
+    ///
     /// // Error tests
     /// let color = Color::hex("");
     /// assert!(color.is_err());
-    /// 
+    ///
     /// let color = Color::hex("#");
     /// assert!(color.is_err());
-    /// 
+    ///
     /// let color = Color::hex("#FFF");
     /// assert!(color.is_err());
     ///
@@ -499,30 +503,24 @@ impl<'a> Color {
     /// let color = Color::hex("#00FF007F").unwrap();
     /// assert_eq!(255, color.g);
     /// ```
-    pub fn hex(hex: &str) -> Result<Color, String> {
-        
+    pub fn hex(hex: &str) -> RasterResult<Color> {
         if hex.len() == 9 && hex.starts_with("#") { // #FFFFFFFF (Red Green Blue Alpha)
-
-            return Ok(Color {
+            Ok(Color {
                 r: try!(_hex_dec(&hex[1..3])),
                 g: try!(_hex_dec(&hex[3..5])),
                 b: try!(_hex_dec(&hex[5..7])),
                 a: try!(_hex_dec(&hex[7..9])),
-            });
-
+            })
         } else if hex.len() == 7 && hex.starts_with("#") { // #FFFFFF (Red Green Blue)
-
-            return Ok(Color {
+            Ok(Color {
                 r: try!(_hex_dec(&hex[1..3])),
                 g: try!(_hex_dec(&hex[3..5])),
                 b: try!(_hex_dec(&hex[5..7])),
                 a: 255,
-            });
-
-        } 
-        
-        Err("Error parsing hex. Example of valid formats: #FFFFFF or #ffffffff".to_string())
-        
+            })
+        } else {
+            Err(RasterError::InvalidHex)
+        }
     }
 
     /// Returns a red Color.
@@ -543,7 +541,7 @@ impl<'a> Color {
     /// use raster::Color;
     ///
     /// let rgb = Color::rgb(0, 255, 0); // Green
-    /// 
+    ///
     /// println!("{:?}", rgb);
     ///
     /// assert_eq!(rgb.r, 0);
@@ -568,7 +566,7 @@ impl<'a> Color {
     /// use raster::Color;
     ///
     /// let rgba = Color::rgba(0, 0, 255, 255); // Blue
-    /// 
+    ///
     /// println!("{:?}", rgba);
     ///
     /// assert_eq!(rgba.r, 0);
@@ -591,7 +589,7 @@ impl<'a> Color {
     /// use raster::Color;
     ///
     /// let hsv = Color::to_hsv(50, 50, 100);
-    /// 
+    ///
     /// assert_eq!(240, hsv.0);
     /// assert_eq!(50.0, (hsv.1).round()); // Saturation in float
     /// assert_eq!(39.0, (hsv.2).round()); // Brightness in float
@@ -624,7 +622,7 @@ impl<'a> Color {
         let mut h = 0.0;
 
         if chroma != 0.0 {
-            
+
             if max == r {
                 h = 60.0 * ((g - b) / chroma);
                 if h < 0.0 {
@@ -644,7 +642,7 @@ impl<'a> Color {
         let v = max;
         let mut s = 0.0;
         if v != 0.0 {
-            
+
             s = chroma / v;
         }
 
@@ -659,7 +657,7 @@ impl<'a> Color {
     /// let rgb1 = (127, 70, 60);
     /// let hsv = Color::to_hsv(rgb1.0, rgb1.1, rgb1.2); // Convert to HSV
     /// let rgb2 = Color::to_rgb(hsv.0, hsv.1, hsv.2); // Convert back to RGB
-    /// 
+    ///
     /// // Check if source RGB is equal to final RGB
     /// assert_eq!(rgb1.0, rgb2.0);
     /// assert_eq!(rgb1.1, rgb2.1);
@@ -727,13 +725,8 @@ impl<'a> Color {
 // Private functions
 
 // Convert a hex string to decimal. Eg. "00" -> 0. "FF" -> 255.
-fn _hex_dec(hex_string: &str) -> Result <u8, String> {
-    match u8::from_str_radix(hex_string, 16) {
-        Ok(o) => {
-            Ok(o as u8)
-        },
-        Err(e) => {
-            Err(format!("Error parsing hex: {}", e).to_string())
-        }
-    }
+fn _hex_dec(hex_string: &str) -> RasterResult<u8> {
+    u8::from_str_radix(hex_string, 16)
+        .map(|o| o as u8)
+        .map_err(RasterError::HexParse)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,11 @@ use error::{RasterError, RasterResult};
 
 /// Create an image from an image file.
 ///
+/// # Errors
+///
+/// At present, this function relies on [image](https://github.com/PistonDevelopers/image), and
+/// thus returns `RasterError::Image` upon failure.
+///
 /// # Examples
 ///
 /// ```
@@ -135,6 +140,10 @@ pub fn open(image_file: &str) -> RasterResult<Image> {
 }
 
 /// Save an image to an image file. The image type is detected from the file extension of the file name.
+///
+/// # Errors
+///
+/// If writing to a file fails, this function returns `RasterError::Io`.
 ///
 /// # Examples
 ///
@@ -334,6 +343,11 @@ impl<'a> Image {
 
     /// Get pixel in a given x and y location of an image.
     ///
+    /// # Errors
+    ///
+    /// If either the x or y coordinate falls out of bounds, this will fail with
+    /// `RasterError::PixelOutOfBounds`.
+    ///
     /// # Examples
     ///
     /// ```
@@ -370,6 +384,14 @@ impl<'a> Image {
     }
 
     /// Set pixel in a given x and y location of an image.
+    ///
+    /// # Errors
+    ///
+    /// If either the x or y coordinate falls out of bounds, this will fail with
+    /// `RasterError::PixelOutOfBounds`.
+    ///
+    /// If the calculated byte start index is less than 0, this will fail with
+    /// `RasterError::InvalidStartIndex`.
     ///
     /// # Examples
     ///
@@ -471,6 +493,12 @@ impl<'a> Color {
     /// Create a color from hexadecimal value.
     ///
     /// Example of valid formats: #FFFFFF, #ffeecc, #00ff007f
+    ///
+    /// # Errors
+    ///
+    /// If the hex *string* is malformed (doesn't begin with `#` or is of invalid length) then this
+    /// fails with `RasterError::InvalidHex`. If it passes that, but the string can't be parsed
+    /// into actual values, then this fails with `RasterError::HexParse`.
     ///
     /// # Examples
     /// ```

--- a/src/position.rs
+++ b/src/position.rs
@@ -8,6 +8,10 @@
 
 // from external crate
 
+
+// from local crate
+use error::{RasterError, RasterResult};
+
 /// Struct for computing position on an image.
 pub struct Position<'a> {
     position: &'a str,
@@ -25,7 +29,7 @@ impl<'a> Position<'a> {
     }
 
     /// Get X and Y position based on parameters.
-    pub fn get_x_y(&self, canvas_width: i32, canvas_height: i32, image_width:i32, image_height:i32) -> Result<(i32, i32), String> {
+    pub fn get_x_y(&self, canvas_width: i32, canvas_height: i32, image_width:i32, image_height:i32) -> RasterResult<(i32, i32)> {
         let offset_x = self.offset_x;
         let offset_y = self.offset_y;
 
@@ -69,9 +73,7 @@ impl<'a> Position<'a> {
                 let y = ((canvas_height / 2) - (image_height / 2)) + offset_y;
                 Ok((x, y))
             },
-            _ => {
-                Err(format!("Invalid position {}.", self.position))
-            }
+            _ => Err(RasterError::InvalidPositionType(self.position.to_string()))
         }
     }
 }

--- a/tests/filter_tests.rs
+++ b/tests/filter_tests.rs
@@ -7,6 +7,5 @@ fn brightness_test(){
 
     let mut image = raster::open("tests/in/sample.jpg").unwrap();
     filter::brightness(&mut image, 1.5).unwrap();
-    raster::save(&image, "tests/out/test_filter_brightness.jpg");
+    raster::save(&image, "tests/out/test_filter_brightness.jpg").unwrap();
 }
-


### PR DESCRIPTION
Closes #1 and #2 

This changes all functions that returned `Result<T, String>` to instead return `RasterResult<T>` (an alias for `Result<T, RasterError>`), and removes the few remaining unwraps. It also streamlines a few pattern matches using map/etc., though I tried not to go overboard on changes like that, for the sake of keeping this pull request nice and focused.

My only concerns are A) it seems my editor stripped some whitespace in a few places; I'm not sure if that's good or bad, and B) `RasterError::BlendingImageFallsOutsideCanvas` might not be the best name.