### PR TITLE
Replace string-based flags with enums

### DIFF
--- a/src/blend.rs
+++ b/src/blend.rs
@@ -16,6 +16,7 @@ use error::RasterResult;
 use Image;
 use Color;
 
+/// An enum for the various modes that can be used for blending.
 #[derive(Debug)]
 pub enum BlendMode {
     Normal,

--- a/src/blend.rs
+++ b/src/blend.rs
@@ -16,6 +16,15 @@ use error::RasterResult;
 use Image;
 use Color;
 
+#[derive(Debug)]
+pub enum BlendMode {
+    Normal,
+    Difference,
+    Multiply,
+    Overlay,
+    Screen
+}
+
 pub fn difference(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, loop_start_x:i32, loop_end_x:i32, offset_x:i32, offset_y:i32, opacity:f32) -> RasterResult<Image> {
 
     let mut canvas = image1.clone();
@@ -36,9 +45,9 @@ pub fn difference(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i
             let g2 = rgba2.g as f32;
             let b2 = rgba2.b as f32;
 
-            let r3 = ch_alpha_f(r1, r2, "difference", a2);
-            let g3 = ch_alpha_f(g1, g2, "difference", a2);
-            let b3 = ch_alpha_f(b1, b2, "difference", a2);
+            let r3 = ch_alpha_f(r1, r2, BlendFunction::Difference, a2);
+            let g3 = ch_alpha_f(g1, g2, BlendFunction::Difference, a2);
+            let b3 = ch_alpha_f(b1, b2, BlendFunction::Difference, a2);
             let a3 = 255;
 
             try!(canvas.set_pixel(canvas_x, canvas_y, Color::rgba(r3 as u8, g3 as u8, b3 as u8, a3 as u8)));
@@ -68,9 +77,9 @@ pub fn multiply(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32
             let g2 = rgba2.g as f32;
             let b2 = rgba2.b as f32;
 
-            let r3 = ch_alpha_f(r1, r2, "multiply", a2);
-            let g3 = ch_alpha_f(g1, g2, "multiply", a2);
-            let b3 = ch_alpha_f(b1, b2, "multiply", a2);
+            let r3 = ch_alpha_f(r1, r2, BlendFunction::Multiply, a2);
+            let g3 = ch_alpha_f(g1, g2, BlendFunction::Multiply, a2);
+            let b3 = ch_alpha_f(b1, b2, BlendFunction::Multiply, a2);
             let a3 = 255;
 
             try!(canvas.set_pixel(canvas_x, canvas_y, Color::rgba(r3 as u8, g3 as u8, b3 as u8, a3 as u8)));
@@ -132,9 +141,9 @@ pub fn overlay(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32,
             let g2 = rgba2.g as f32;
             let b2 = rgba2.b as f32;
 
-            let r3 = ch_alpha_f(r1, r2, "overlay", a2);
-            let g3 = ch_alpha_f(g1, g2, "overlay", a2);
-            let b3 = ch_alpha_f(b1, b2, "overlay", a2);
+            let r3 = ch_alpha_f(r1, r2, BlendFunction::Overlay, a2);
+            let g3 = ch_alpha_f(g1, g2, BlendFunction::Overlay, a2);
+            let b3 = ch_alpha_f(b1, b2, BlendFunction::Overlay, a2);
             let a3 = 255;
 
             try!(canvas.set_pixel(canvas_x, canvas_y, Color::rgba(r3 as u8, g3 as u8, b3 as u8, a3 as u8)));
@@ -164,9 +173,9 @@ pub fn screen(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, 
             let g2 = rgba2.g as f32;
             let b2 = rgba2.b as f32;
 
-            let r3 = ch_alpha_f(r1, r2, "screen", a2);
-            let g3 = ch_alpha_f(g1, g2, "screen", a2);
-            let b3 = ch_alpha_f(b1, b2, "screen", a2);
+            let r3 = ch_alpha_f(r1, r2, BlendFunction::Screen, a2);
+            let g3 = ch_alpha_f(g1, g2, BlendFunction::Screen, a2);
+            let b3 = ch_alpha_f(b1, b2, BlendFunction::Screen, a2);
             let a3 = 255;
 
             try!(canvas.set_pixel(canvas_x, canvas_y, Color::rgba(r3 as u8, g3 as u8, b3 as u8, a3 as u8)));
@@ -180,13 +189,25 @@ pub fn screen(image1: &Image, image2: &Image, loop_start_y:i32, loop_end_y:i32, 
 // base, top 0.0 - 255.0
 // opacity 0.0 - 1.0
 
-fn ch_alpha_f(base: f32, top: f32, f: &str, opacity: f32) -> f32 {
+/*
+This is the private BlendFunction enum, not to be confused with BlendMode, which is for public
+consumption! BlendFunction differs only in lacking a Normal variant, as ch_alpha_f has no need for
+such things.
+*/
+#[derive(Debug)]
+enum BlendFunction {
+    Difference,
+    Multiply,
+    Overlay,
+    Screen
+}
+
+fn ch_alpha_f(base: f32, top: f32, f: BlendFunction, opacity: f32) -> f32 {
     match f {
-        "difference" => ch_alpha( base, ch_difference( base, top ), opacity ),
-        "multiply" => ch_alpha( base, ch_multiply( base, top ), opacity ),
-        "overlay" => ch_alpha( base, ch_overlay( base, top ), opacity ),
-        "screen" => ch_alpha( base, ch_screen( base, top ), opacity ),
-        _ => panic!("Invalid blend function.") // TODO:
+        BlendFunction::Difference => ch_alpha( base, ch_difference( base, top ), opacity ),
+        BlendFunction::Multiply => ch_alpha( base, ch_multiply( base, top ), opacity ),
+        BlendFunction::Overlay => ch_alpha( base, ch_overlay( base, top ), opacity ),
+        BlendFunction::Screen => ch_alpha( base, ch_screen( base, top ), opacity )
     }
 }
 

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -9,7 +9,7 @@
 // from local crate
 use error::RasterResult;
 use Image;
-use editor;
+use editor::{self, ResizeMode};
 
 /// Compare two images and returns a hamming distance. A value of 0 indicates a likely similar picture.
 /// A value between 1 and 10 is potentially a variation. A value greater than 10 is likely a different image.
@@ -104,7 +104,7 @@ fn diff_hash(image: &Image) -> RasterResult<Vec<u8>> {
     let height = 8;
 
     let mut image = image.clone(); // copy it since resize is desctructive
-    try!(editor::resize(&mut image, width, height, "exact")); // Resize to exactly 9x8
+    try!(editor::resize(&mut image, width, height, ResizeMode::Exact)); // Resize to exactly 9x8
 
     // Build hash
     let mut hash = Vec::new();

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -309,14 +309,6 @@ pub enum ResizeMode {
 
 /// Resize an image to a given width, height and mode.
 ///
-/// # Modes
-///
-/// * `Exact` - Resize image to exact dimensions ignoring aspect ratio.
-/// * `ExactWidth` - Resize image to exact width. Height parameter is ignored and is auto calculated instead.
-/// * `ExactHeight` - Resize image to exact height. Width parameter is ignored and is auto calculated instead.
-/// * `Fit` - Resize an image to fit within the given width and height.
-/// * `Fill` - Resize image to fill all the space in the given dimension. Excess parts are cropped.
-///
 /// # Examples
 /// ### Resize Fit
 /// ```

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -309,7 +309,7 @@ pub enum ResizeMode {
 
 /// Resize an image to a given width, height and mode.
 ///
-/// Modes:
+/// # Modes
 ///
 /// * `Exact` - Resize image to exact dimensions ignoring aspect ratio.
 /// * `ExactWidth` - Resize image to exact width. Height parameter is ignored and is auto calculated instead.

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -13,30 +13,10 @@ use error::{RasterError, RasterResult};
 use blend::{self, BlendMode};
 use Color;
 use Image;
-use position::Position;
+use position::{Position, PositionType};
 use transform;
 
 /// Blend 2 images into one. The image1 is the base and image2 is the top.
-///
-/// Supported blend modes:
-///
-/// * normal
-/// * difference
-/// * multiply
-/// * overlay
-/// * screen
-///
-/// Possible position:
-///
-/// * top-left
-/// * top-center
-/// * top-right
-/// * center-left
-/// * center
-/// * center-right
-/// * bottom-left
-/// * bottom-center
-/// * bottom-right
 ///
 /// Opacity is any value from 0.0 - 1.0
 ///
@@ -44,21 +24,20 @@ use transform;
 ///
 /// # Examples
 /// ```
-/// use raster::editor;
-/// use raster::BlendMode;
+/// use raster::{editor, BlendMode, PositionType};
 ///
 /// // Create images from file
 /// let image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let image2 = raster::open("tests/in/watermark.png").unwrap();
 ///
 /// // Blend image2 on top of image1 using normal mode, opacity of 1.0 (100%), with image2 at the center, with 0 x and 0 y offsets. whew
-/// let normal = editor::blend(&image1, &image2, BlendMode::Normal, 1.0, "center", 0, 0).unwrap();
+/// let normal = editor::blend(&image1, &image2, BlendMode::Normal, 1.0, PositionType::Center, 0, 0).unwrap();
 ///
 /// // All the other blend modes
-/// let difference = editor::blend(&image1, &image2, BlendMode::Difference, 1.0, "center", 0, 0).unwrap();
-/// let multiply = editor::blend(&image1, &image2, BlendMode::Multiply, 1.0, "center", 0, 0).unwrap();
-/// let overlay = editor::blend(&image1, &image2, BlendMode::Overlay, 1.0, "center", 0, 0).unwrap();
-/// let screen = editor::blend(&image1, &image2, BlendMode::Screen, 1.0, "center", 0, 0).unwrap();
+/// let difference = editor::blend(&image1, &image2, BlendMode::Difference, 1.0, PositionType::Center, 0, 0).unwrap();
+/// let multiply = editor::blend(&image1, &image2, BlendMode::Multiply, 1.0, PositionType::Center, 0, 0).unwrap();
+/// let overlay = editor::blend(&image1, &image2, BlendMode::Overlay, 1.0, PositionType::Center, 0, 0).unwrap();
+/// let screen = editor::blend(&image1, &image2, BlendMode::Screen, 1.0, PositionType::Center, 0, 0).unwrap();
 ///
 /// // Save it
 /// raster::save(&normal, "tests/out/test_blend_normal.png");
@@ -102,7 +81,7 @@ use transform;
 ///
 /// ![](https://kosinix.github.io/raster/out/test_blend_screen.png)
 ///
-pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity: f32, position: &str, offset_x: i32, offset_y: i32) -> RasterResult<Image> {
+pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity: f32, position: PositionType, offset_x: i32, offset_y: i32) -> RasterResult<Image> {
 
     let mut opacity = opacity;
     if opacity > 1.0 {
@@ -177,19 +156,7 @@ pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity:
 
 /// Crop the image to the given dimension and position.
 ///
-/// Possible position:
-///
-/// * top-left
-/// * top-center
-/// * top-right
-/// * center-left
-/// * center
-/// * center-right
-/// * bottom-left
-/// * bottom-center
-/// * bottom-right
-///
-/// The offset_x and offset_y are added to the final position. Can also be negative offsets. Offsets can be used to nudge the final position. Or you can set the position to "top-left" and use the offsets as a normal screen x and y coordinates.
+/// The offset_x and offset_y are added to the final position. Can also be negative offsets. Offsets can be used to nudge the final position. Or you can set the position to PositionType::TopLeft and use the offsets as a normal screen x and y coordinates.
 ///
 /// # Examples
 ///
@@ -200,7 +167,7 @@ pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity:
 /// ### Code
 ///
 /// ```
-/// use raster::editor;
+/// use raster::{editor, PositionType};
 ///
 /// // Create image from file
 /// let mut top_left = raster::open("tests/in/crop-test.jpg").unwrap();
@@ -218,17 +185,17 @@ pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity:
 /// let mut bottom_right = top_left.clone();
 ///
 /// // Crop it
-/// editor::crop(&mut top_left, 167, 93, "top-left", 0, 0).unwrap();
-/// editor::crop(&mut top_center, 166, 93, "top-center", 0, 0).unwrap();
-/// editor::crop(&mut top_right, 167, 93, "top-right", 0, 0).unwrap();
+/// editor::crop(&mut top_left, 167, 93, PositionType::TopLeft, 0, 0).unwrap();
+/// editor::crop(&mut top_center, 166, 93, PositionType::TopCenter, 0, 0).unwrap();
+/// editor::crop(&mut top_right, 167, 93, PositionType::TopRight, 0, 0).unwrap();
 ///
-/// editor::crop(&mut center_left, 167, 93, "center-left", 0, 0).unwrap();
-/// editor::crop(&mut center, 166, 93, "center", 0, 0).unwrap();
-/// editor::crop(&mut center_right, 167, 93, "center-right", 0, 0).unwrap();
+/// editor::crop(&mut center_left, 167, 93, PositionType::CenterLeft, 0, 0).unwrap();
+/// editor::crop(&mut center, 166, 93, PositionType::Center, 0, 0).unwrap();
+/// editor::crop(&mut center_right, 167, 93, PositionType::CenterRight, 0, 0).unwrap();
 ///
-/// editor::crop(&mut bottom_left, 167, 93, "bottom-left", 0, 0).unwrap();
-/// editor::crop(&mut bottom_center, 166, 93, "bottom-center", 0, 0).unwrap();
-/// editor::crop(&mut bottom_right, 167, 93, "bottom-right", 0, 0).unwrap();
+/// editor::crop(&mut bottom_left, 167, 93, PositionType::BottomLeft, 0, 0).unwrap();
+/// editor::crop(&mut bottom_center, 166, 93, PositionType::BottomCenter, 0, 0).unwrap();
+/// editor::crop(&mut bottom_right, 167, 93, PositionType::BottomRight, 0, 0).unwrap();
 ///
 /// // Save it
 /// raster::save(&top_left, "tests/out/test_crop_top_left.jpg");
@@ -257,7 +224,7 @@ pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity:
 /// ![](https://kosinix.github.io/raster/out/test_crop_bottom_center.jpg)
 /// ![](https://kosinix.github.io/raster/out/test_crop_bottom_right.jpg)
 ///
-pub fn crop<'a>(mut src: &'a mut Image, crop_width: i32, crop_height: i32, position: &str, offset_x: i32, offset_y: i32) -> RasterResult<()> {
+pub fn crop<'a>(mut src: &'a mut Image, crop_width: i32, crop_height: i32, position: PositionType, offset_x: i32, offset_y: i32) -> RasterResult<()> {
 
     // Turn into positioner struct
     let positioner = Position::new(position, offset_x, offset_y);
@@ -322,38 +289,49 @@ pub fn fill(mut src: &mut Image, color: Color) -> RasterResult<()> {
     Ok(())
 }
 
+#[derive(Debug)]
+pub enum ResizeMode {
+    /// Resize image to exact dimensions ignoring aspect ratio.
+    Exact,
+    /// Resize image to exact width. Height parameter is ignored and is auto calculated instead.
+    ExactWidth,
+    /// Resize image to exact height. Width parameter is ignored and is auto calculated instead.
+    ExactHeight,
+    /// Resize an image to fit within the given width and height.
+    Fit,
+    /// Resize image to fill all the space in the given dimension. Excess parts are cropped.
+    Fill
+}
+
 /// Resize an image to a given width, height and mode.
 ///
 /// Modes:
 ///
-/// * exact - Resize image to exact dimensions ignoring aspect ratio.
-/// * exact_width - Resize image to exact width. Height parameter is ignored and is auto calculated instead.
-/// * exact_height - Resize image to exact height. Width parameter is ignored and is auto calculated instead.
-/// * fit - Resize an image to fit within the given width and height.
-/// * fill - Resize image to fill all the space in the given dimension. Excess parts are cropped.
+/// * Exact - Resize image to exact dimensions ignoring aspect ratio.
+/// * ExactWidth - Resize image to exact width. Height parameter is ignored and is auto calculated instead.
+/// * ExactHeight - Resize image to exact height. Width parameter is ignored and is auto calculated instead.
+/// * Fit - Resize an image to fit within the given width and height.
+/// * Fill - Resize image to fill all the space in the given dimension. Excess parts are cropped.
 ///
 /// # Examples
 /// ### Resize Fit
 /// ```
-/// use raster::editor;
-/// use raster::Color;
-/// use raster::Image;
-/// use raster::BlendMode;
+/// use raster::{editor, Color, Image, ResizeMode, BlendMode, PositionType};
 ///
 /// // Create an image from file
 /// let mut image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let mut image2 = raster::open("tests/in/portrait.jpg").unwrap();
 ///
 /// // Resize it
-/// editor::resize(&mut image1, 200, 200, "fit");
-/// editor::resize(&mut image2, 200, 200, "fit");
+/// editor::resize(&mut image1, 200, 200, ResizeMode::Fit);
+/// editor::resize(&mut image2, 200, 200, ResizeMode::Fit);
 ///
 /// // Superimpose images on a gray background
 /// let mut bg = Image::blank(200, 200);
 /// editor::fill(&mut bg, Color::hex("#CCCCCC").unwrap());
 ///
-/// let image1 = editor::blend(&bg, &image1, BlendMode::Normal, 1.0, "top-left", 0, 0).unwrap();
-/// let image2 = editor::blend(&bg, &image2, BlendMode::Normal, 1.0, "top-left", 0, 0).unwrap();
+/// let image1 = editor::blend(&bg, &image1, BlendMode::Normal, 1.0, PositionType::TopLeft, 0, 0).unwrap();
+/// let image2 = editor::blend(&bg, &image2, BlendMode::Normal, 1.0, PositionType::TopLeft, 0, 0).unwrap();
 ///
 /// raster::save(&image1, "tests/out/test_resize_fit_1.jpg");
 /// raster::save(&image2, "tests/out/test_resize_fit_2.jpg");
@@ -361,21 +339,20 @@ pub fn fill(mut src: &mut Image, color: Color) -> RasterResult<()> {
 ///
 /// The gray box shows the 200x200 imaginary box that the images "fit" in.
 ///
+///
 /// ![](https://kosinix.github.io/raster/out/test_resize_fit_1.jpg) ![](https://kosinix.github.io/raster/out/test_resize_fit_2.jpg)
 ///
 /// ### Resize Fill
 /// ```
-/// use raster::editor;
-/// use raster::Color;
-/// use raster::Image;
+/// use raster::{editor, Color, Image, ResizeMode};
 ///
 /// // Create an image from file
 /// let mut image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let mut image2 = raster::open("tests/in/portrait.jpg").unwrap();
 ///
 /// // Resize it
-/// editor::resize(&mut image1, 200, 200, "fill");
-/// editor::resize(&mut image2, 200, 200, "fill");
+/// editor::resize(&mut image1, 200, 200, ResizeMode::Fill);
+/// editor::resize(&mut image2, 200, 200, ResizeMode::Fill);
 ///
 /// raster::save(&image1, "tests/out/test_resize_fill_1.jpg");
 /// raster::save(&image2, "tests/out/test_resize_fill_2.jpg");
@@ -387,17 +364,15 @@ pub fn fill(mut src: &mut Image, color: Color) -> RasterResult<()> {
 ///
 /// ### Resize to Exact Width
 /// ```
-/// use raster::editor;
-/// use raster::Color;
-/// use raster::Image;
+/// use raster::{editor, Color, Image, ResizeMode};
 ///
 /// // Create an image from file
 /// let mut image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let mut image2 = raster::open("tests/in/portrait.jpg").unwrap();
 ///
 /// // Resize it
-/// editor::resize(&mut image1, 200, 200, "exact_width");
-/// editor::resize(&mut image2, 200, 200, "exact_width");
+/// editor::resize(&mut image1, 200, 200, ResizeMode::ExactWidth);
+/// editor::resize(&mut image2, 200, 200, ResizeMode::ExactWidth);
 ///
 /// raster::save(&image1, "tests/out/test_resize_exact_width_1.jpg");
 /// raster::save(&image2, "tests/out/test_resize_exact_width_2.jpg");
@@ -410,17 +385,15 @@ pub fn fill(mut src: &mut Image, color: Color) -> RasterResult<()> {
 ///
 /// ### Resize to Exact Height
 /// ```
-/// use raster::editor;
-/// use raster::Color;
-/// use raster::Image;
+/// use raster::{editor, Color, Image, ResizeMode};
 ///
 /// // Create an image from file
 /// let mut image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let mut image2 = raster::open("tests/in/portrait.jpg").unwrap();
 ///
 /// // Resize it
-/// editor::resize(&mut image1, 200, 200, "exact_height");
-/// editor::resize(&mut image2, 200, 200, "exact_height");
+/// editor::resize(&mut image1, 200, 200, ResizeMode::ExactHeight);
+/// editor::resize(&mut image2, 200, 200, ResizeMode::ExactHeight);
 ///
 /// raster::save(&image1, "tests/out/test_resize_exact_height_1.jpg");
 /// raster::save(&image2, "tests/out/test_resize_exact_height_2.jpg");
@@ -432,17 +405,15 @@ pub fn fill(mut src: &mut Image, color: Color) -> RasterResult<()> {
 ///
 /// ### Resize to Exact Dimension
 /// ```
-/// use raster::editor;
-/// use raster::Color;
-/// use raster::Image;
+/// use raster::{editor, Color, Image, ResizeMode};
 ///
 /// // Create an image from file
 /// let mut image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let mut image2 = raster::open("tests/in/portrait.jpg").unwrap();
 ///
 /// // Resize it
-/// editor::resize(&mut image1, 200, 200, "exact");
-/// editor::resize(&mut image2, 200, 200, "exact");
+/// editor::resize(&mut image1, 200, 200, ResizeMode::Exact);
+/// editor::resize(&mut image2, 200, 200, ResizeMode::Exact);
 ///
 /// raster::save(&image1, "tests/out/test_resize_exact_1.jpg");
 /// raster::save(&image2, "tests/out/test_resize_exact_2.jpg");
@@ -452,13 +423,12 @@ pub fn fill(mut src: &mut Image, color: Color) -> RasterResult<()> {
 ///
 /// ![](https://kosinix.github.io/raster/out/test_resize_exact_1.jpg) ![](https://kosinix.github.io/raster/out/test_resize_exact_2.jpg)
 ///
-pub fn resize<'a>(mut src: &'a mut Image, w: i32, h: i32, mode: &str) -> RasterResult<()> {
+pub fn resize<'a>(mut src: &'a mut Image, w: i32, h: i32, mode: ResizeMode) -> RasterResult<()> {
     match mode {
-        "exact" => transform::resize_exact(&mut src, w, h),
-        "exact_width" => transform::resize_exact_width(&mut src, w),
-        "exact_height" => transform::resize_exact_height(&mut src, h),
-        "fit" => transform::resize_fit(&mut src, w, h),
-        "fill" => transform::resize_fill(&mut src, w, h),
-        _ => Err(RasterError::InvalidResiveMode(mode.to_string()))
+        ResizeMode::Exact => transform::resize_exact(&mut src, w, h),
+        ResizeMode::ExactWidth => transform::resize_exact_width(&mut src, w),
+        ResizeMode::ExactHeight => transform::resize_exact_height(&mut src, h),
+        ResizeMode::Fit => transform::resize_fit(&mut src, w, h),
+        ResizeMode::Fill => transform::resize_fill(&mut src, w, h)
     }.map(|_| ())
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -13,7 +13,7 @@ use error::{RasterError, RasterResult};
 use blend::{self, BlendMode};
 use Color;
 use Image;
-use position::{Position, PositionType};
+use position::{Position, PositionMode};
 use transform;
 
 /// Blend 2 images into one. The image1 is the base and image2 is the top.
@@ -28,20 +28,20 @@ use transform;
 ///
 /// # Examples
 /// ```
-/// use raster::{editor, BlendMode, PositionType};
+/// use raster::{editor, BlendMode, PositionMode};
 ///
 /// // Create images from file
 /// let image1 = raster::open("tests/in/sample.jpg").unwrap();
 /// let image2 = raster::open("tests/in/watermark.png").unwrap();
 ///
 /// // Blend image2 on top of image1 using normal mode, opacity of 1.0 (100%), with image2 at the center, with 0 x and 0 y offsets. whew
-/// let normal = editor::blend(&image1, &image2, BlendMode::Normal, 1.0, PositionType::Center, 0, 0).unwrap();
+/// let normal = editor::blend(&image1, &image2, BlendMode::Normal, 1.0, PositionMode::Center, 0, 0).unwrap();
 ///
 /// // All the other blend modes
-/// let difference = editor::blend(&image1, &image2, BlendMode::Difference, 1.0, PositionType::Center, 0, 0).unwrap();
-/// let multiply = editor::blend(&image1, &image2, BlendMode::Multiply, 1.0, PositionType::Center, 0, 0).unwrap();
-/// let overlay = editor::blend(&image1, &image2, BlendMode::Overlay, 1.0, PositionType::Center, 0, 0).unwrap();
-/// let screen = editor::blend(&image1, &image2, BlendMode::Screen, 1.0, PositionType::Center, 0, 0).unwrap();
+/// let difference = editor::blend(&image1, &image2, BlendMode::Difference, 1.0, PositionMode::Center, 0, 0).unwrap();
+/// let multiply = editor::blend(&image1, &image2, BlendMode::Multiply, 1.0, PositionMode::Center, 0, 0).unwrap();
+/// let overlay = editor::blend(&image1, &image2, BlendMode::Overlay, 1.0, PositionMode::Center, 0, 0).unwrap();
+/// let screen = editor::blend(&image1, &image2, BlendMode::Screen, 1.0, PositionMode::Center, 0, 0).unwrap();
 ///
 /// // Save it
 /// raster::save(&normal, "tests/out/test_blend_normal.png");
@@ -85,7 +85,7 @@ use transform;
 ///
 /// ![](https://kosinix.github.io/raster/out/test_blend_screen.png)
 ///
-pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity: f32, position: PositionType, offset_x: i32, offset_y: i32) -> RasterResult<Image> {
+pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity: f32, position: PositionMode, offset_x: i32, offset_y: i32) -> RasterResult<Image> {
 
     let mut opacity = opacity;
     if opacity > 1.0 {
@@ -160,7 +160,7 @@ pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity:
 
 /// Crop the image to the given dimension and position.
 ///
-/// The `offset_x` and `offset_y` are added to the final position. Can also be negative offsets. Offsets can be used to nudge the final position. Or you can set the position to `PositionType::TopLeft` and use the offsets as a normal screen x and y coordinates.
+/// The `offset_x` and `offset_y` are added to the final position. Can also be negative offsets. Offsets can be used to nudge the final position. Or you can set the position to `PositionMode::TopLeft` and use the offsets as a normal screen x and y coordinates.
 ///
 /// # Examples
 ///
@@ -171,7 +171,7 @@ pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity:
 /// ### Code
 ///
 /// ```
-/// use raster::{editor, PositionType};
+/// use raster::{editor, PositionMode};
 ///
 /// // Create image from file
 /// let mut top_left = raster::open("tests/in/crop-test.jpg").unwrap();
@@ -189,17 +189,17 @@ pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity:
 /// let mut bottom_right = top_left.clone();
 ///
 /// // Crop it
-/// editor::crop(&mut top_left, 167, 93, PositionType::TopLeft, 0, 0).unwrap();
-/// editor::crop(&mut top_center, 166, 93, PositionType::TopCenter, 0, 0).unwrap();
-/// editor::crop(&mut top_right, 167, 93, PositionType::TopRight, 0, 0).unwrap();
+/// editor::crop(&mut top_left, 167, 93, PositionMode::TopLeft, 0, 0).unwrap();
+/// editor::crop(&mut top_center, 166, 93, PositionMode::TopCenter, 0, 0).unwrap();
+/// editor::crop(&mut top_right, 167, 93, PositionMode::TopRight, 0, 0).unwrap();
 ///
-/// editor::crop(&mut center_left, 167, 93, PositionType::CenterLeft, 0, 0).unwrap();
-/// editor::crop(&mut center, 166, 93, PositionType::Center, 0, 0).unwrap();
-/// editor::crop(&mut center_right, 167, 93, PositionType::CenterRight, 0, 0).unwrap();
+/// editor::crop(&mut center_left, 167, 93, PositionMode::CenterLeft, 0, 0).unwrap();
+/// editor::crop(&mut center, 166, 93, PositionMode::Center, 0, 0).unwrap();
+/// editor::crop(&mut center_right, 167, 93, PositionMode::CenterRight, 0, 0).unwrap();
 ///
-/// editor::crop(&mut bottom_left, 167, 93, PositionType::BottomLeft, 0, 0).unwrap();
-/// editor::crop(&mut bottom_center, 166, 93, PositionType::BottomCenter, 0, 0).unwrap();
-/// editor::crop(&mut bottom_right, 167, 93, PositionType::BottomRight, 0, 0).unwrap();
+/// editor::crop(&mut bottom_left, 167, 93, PositionMode::BottomLeft, 0, 0).unwrap();
+/// editor::crop(&mut bottom_center, 166, 93, PositionMode::BottomCenter, 0, 0).unwrap();
+/// editor::crop(&mut bottom_right, 167, 93, PositionMode::BottomRight, 0, 0).unwrap();
 ///
 /// // Save it
 /// raster::save(&top_left, "tests/out/test_crop_top_left.jpg");
@@ -228,7 +228,7 @@ pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity:
 /// ![](https://kosinix.github.io/raster/out/test_crop_bottom_center.jpg)
 /// ![](https://kosinix.github.io/raster/out/test_crop_bottom_right.jpg)
 ///
-pub fn crop<'a>(mut src: &'a mut Image, crop_width: i32, crop_height: i32, position: PositionType, offset_x: i32, offset_y: i32) -> RasterResult<()> {
+pub fn crop<'a>(mut src: &'a mut Image, crop_width: i32, crop_height: i32, position: PositionMode, offset_x: i32, offset_y: i32) -> RasterResult<()> {
 
     // Turn into positioner struct
     let positioner = Position::new(position, offset_x, offset_y);
@@ -320,7 +320,7 @@ pub enum ResizeMode {
 /// # Examples
 /// ### Resize Fit
 /// ```
-/// use raster::{editor, Color, Image, ResizeMode, BlendMode, PositionType};
+/// use raster::{editor, Color, Image, ResizeMode, BlendMode, PositionMode};
 ///
 /// // Create an image from file
 /// let mut image1 = raster::open("tests/in/sample.jpg").unwrap();
@@ -334,8 +334,8 @@ pub enum ResizeMode {
 /// let mut bg = Image::blank(200, 200);
 /// editor::fill(&mut bg, Color::hex("#CCCCCC").unwrap());
 ///
-/// let image1 = editor::blend(&bg, &image1, BlendMode::Normal, 1.0, PositionType::TopLeft, 0, 0).unwrap();
-/// let image2 = editor::blend(&bg, &image2, BlendMode::Normal, 1.0, PositionType::TopLeft, 0, 0).unwrap();
+/// let image1 = editor::blend(&bg, &image1, BlendMode::Normal, 1.0, PositionMode::TopLeft, 0, 0).unwrap();
+/// let image2 = editor::blend(&bg, &image2, BlendMode::Normal, 1.0, PositionMode::TopLeft, 0, 0).unwrap();
 ///
 /// raster::save(&image1, "tests/out/test_resize_fit_1.jpg");
 /// raster::save(&image2, "tests/out/test_resize_fit_2.jpg");

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -20,7 +20,7 @@ use transform;
 ///
 /// Opacity is any value from 0.0 - 1.0
 ///
-/// The offset_x and offset_y are added to the final position. Can also be negative offsets.
+/// The `offset_x` and `offset_y` are added to the final position. Can also be negative offsets.
 ///
 /// # Errors
 ///
@@ -160,7 +160,7 @@ pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity:
 
 /// Crop the image to the given dimension and position.
 ///
-/// The offset_x and offset_y are added to the final position. Can also be negative offsets. Offsets can be used to nudge the final position. Or you can set the position to PositionType::TopLeft and use the offsets as a normal screen x and y coordinates.
+/// The `offset_x` and `offset_y` are added to the final position. Can also be negative offsets. Offsets can be used to nudge the final position. Or you can set the position to `PositionType::TopLeft` and use the offsets as a normal screen x and y coordinates.
 ///
 /// # Examples
 ///
@@ -311,11 +311,11 @@ pub enum ResizeMode {
 ///
 /// Modes:
 ///
-/// * Exact - Resize image to exact dimensions ignoring aspect ratio.
-/// * ExactWidth - Resize image to exact width. Height parameter is ignored and is auto calculated instead.
-/// * ExactHeight - Resize image to exact height. Width parameter is ignored and is auto calculated instead.
-/// * Fit - Resize an image to fit within the given width and height.
-/// * Fill - Resize image to fill all the space in the given dimension. Excess parts are cropped.
+/// * `Exact` - Resize image to exact dimensions ignoring aspect ratio.
+/// * `ExactWidth` - Resize image to exact width. Height parameter is ignored and is auto calculated instead.
+/// * `ExactHeight` - Resize image to exact height. Width parameter is ignored and is auto calculated instead.
+/// * `Fit` - Resize an image to fit within the given width and height.
+/// * `Fill` - Resize image to fill all the space in the given dimension. Excess parts are cropped.
 ///
 /// # Examples
 /// ### Resize Fit

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -293,6 +293,7 @@ pub fn fill(mut src: &mut Image, color: Color) -> RasterResult<()> {
     Ok(())
 }
 
+/// An enum for the various modes that can be used for resizing.
 #[derive(Debug)]
 pub enum ResizeMode {
     /// Resize image to exact dimensions ignoring aspect ratio.

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,6 @@ pub enum RasterError {
     All of these invalid mode/type errors will be unneeded once mode/type flags are switched
     to using enums rather than strings.
     */
-    InvalidBlendMode(String),
     InvalidResiveMode(String),
     InvalidBlurMode(String),
     InvalidInterpolationMode(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,17 +18,7 @@ pub enum RasterError {
     In an ideal world, image's error type needn't be exposed
     (but we don't live in an ideal world yet)
     */
-    Image(ImageError),
-
-    /*
-    All of these invalid mode/type errors will be unneeded once mode/type flags are switched
-    to using enums rather than strings.
-    */
-    InvalidResiveMode(String),
-    InvalidBlurMode(String),
-    InvalidInterpolationMode(String),
-    InvalidTransformMode(String),
-    InvalidPositionType(String)
+    Image(ImageError)
 }
 
 pub type RasterResult<T> = Result<T, RasterError>;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -14,6 +14,7 @@ use error::{RasterError, RasterResult};
 use Image;
 use Color;
 
+/// An enum for the various modes that can be used for blurring.
 #[derive(Debug)]
 pub enum BlurMode {
     Box,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -14,17 +14,23 @@ use error::{RasterError, RasterResult};
 use Image;
 use Color;
 
+#[derive(Debug)]
+pub enum BlurMode {
+    Box,
+    Gaussian
+}
+
 /// Apply box or Gaussian blur.
 ///
 /// # Examples
 /// ### Box Blur
 ///
 /// ```
-/// use raster::filter;
+/// use raster::{filter, BlurMode};
 ///
 /// // Create image from file
 /// let mut image = raster::open("tests/in/sample.jpg").unwrap();
-/// filter::blur(&mut image, "box").unwrap();
+/// filter::blur(&mut image, BlurMode::Box).unwrap();
 /// raster::save(&image, "tests/out/test_filter_box_blur.jpg");
 /// ```
 /// ### Before
@@ -36,11 +42,11 @@ use Color;
 /// ### Gaussian Blur
 ///
 /// ```
-/// use raster::filter;
+/// use raster::{filter, BlurMode};
 ///
 /// // Create image from file
 /// let mut image = raster::open("tests/in/sample.jpg").unwrap();
-/// filter::blur(&mut image, "gaussian").unwrap();
+/// filter::blur(&mut image, BlurMode::Gaussian).unwrap();
 /// raster::save(&image, "tests/out/test_filter_gaussian_blur.jpg");
 /// ```
 /// ### Before
@@ -49,11 +55,10 @@ use Color;
 /// ### After
 /// ![](https://kosinix.github.io/raster/out/test_filter_gaussian_blur.jpg)
 ///
-pub fn blur<'a>(mut src: &'a mut Image, mode: &str) -> RasterResult<()>{
+pub fn blur<'a>(mut src: &'a mut Image, mode: BlurMode) -> RasterResult<()>{
     match mode {
-        "box" => blur_box(&mut src),
-        "gaussian" => blur_gaussian(&mut src),
-        _ => Err(RasterError::InvalidBlurMode(mode.to_string()))
+        BlurMode::Box => blur_box(&mut src),
+        BlurMode::Gaussian => blur_gaussian(&mut src)
     }.map(|_| ())
 }
 

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -14,6 +14,7 @@ use error::RasterResult;
 use Image;
 use Color;
 
+/// An enum for the various modes that can be used for interpolation.
 #[derive(Debug)]
 pub enum InterpolationMode {
     Bilinear,

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -10,17 +10,23 @@ use std::cmp;
 
 
 // from local crate
-use error::{RasterError, RasterResult};
+use error::RasterResult;
 use Image;
 use Color;
 
+#[derive(Debug)]
+pub enum InterpolationMode {
+    Bilinear,
+    Bicubic,
+    Nearest
+}
+
 /// Resample an image into a new size using a given interpolation method.
-pub fn resample<'a>(mut src: &'a mut Image, w: i32, h: i32, interpolation: &str) -> RasterResult<()> {
+pub fn resample<'a>(mut src: &'a mut Image, w: i32, h: i32, interpolation: InterpolationMode) -> RasterResult<()> {
     match interpolation {
-        "bilinear" => bilinear(&mut src, w, h),
-        "bicubic" => bilinear(&mut src, w, h), // TODO: bicubic
-        "nearest" => nearest(&mut src, w, h),
-        _ => Err(RasterError::InvalidInterpolationMode(interpolation.to_string()))
+        InterpolationMode::Bilinear => bilinear(&mut src, w, h),
+        InterpolationMode::Bicubic => bilinear(&mut src, w, h), // TODO: bicubic
+        InterpolationMode::Nearest => nearest(&mut src, w, h)
     }.map(|_| ())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,11 @@ use self::image::GenericImage;
 // from local crate
 use error::{RasterError, RasterResult};
 pub use blend::BlendMode;
+pub use editor::ResizeMode;
+pub use filter::BlurMode;
+pub use interpolate::InterpolationMode;
+pub use position::PositionType;
+pub use transform::TransformMode;
 
 /// Create an image from an image file.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ use self::image::GenericImage;
 
 // from local crate
 use error::{RasterError, RasterResult};
+pub use blend::BlendMode;
 
 /// Create an image from an image file.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ pub use blend::BlendMode;
 pub use editor::ResizeMode;
 pub use filter::BlurMode;
 pub use interpolate::InterpolationMode;
-pub use position::PositionType;
+pub use position::PositionMode;
 pub use transform::TransformMode;
 
 /// Create an image from an image file.

--- a/src/position.rs
+++ b/src/position.rs
@@ -10,17 +10,30 @@
 
 
 // from local crate
-use error::{RasterError, RasterResult};
+use error::RasterResult;
+
+#[derive(Debug)]
+pub enum PositionType {
+    TopLeft,
+    TopCenter,
+    TopRight,
+    CenterLeft,
+    Center,
+    CenterRight,
+    BottomLeft,
+    BottomCenter,
+    BottomRight
+}
 
 /// Struct for computing position on an image.
-pub struct Position<'a> {
-    position: &'a str,
+pub struct Position {
+    position: PositionType,
     offset_x: i32,
     offset_y: i32
 }
 
-impl<'a> Position<'a> {
-    pub fn new(position: &'a str, offset_x: i32, offset_y: i32) -> Position {
+impl Position {
+    pub fn new(position: PositionType, offset_x: i32, offset_y: i32) -> Position {
         Position {
             position: position,
             offset_x: offset_x,
@@ -34,46 +47,45 @@ impl<'a> Position<'a> {
         let offset_y = self.offset_y;
 
         match self.position {
-            "top-left" => {
+            PositionType::TopLeft => {
                 Ok((offset_x, offset_y))
             },
-            "top-center" => {
+            PositionType::TopCenter => {
                 let x = ((canvas_width / 2) - (image_width / 2)) + offset_x;
                 Ok((x, offset_y))
             },
-            "top-right" => {
+            PositionType::TopRight => {
                 let x = (canvas_width - image_width) + offset_x;
                 Ok((x, offset_y))
             },
-            "center-left" => {
+            PositionType::CenterLeft => {
                 let y = ((canvas_height / 2) - (image_height / 2)) + offset_x;
                 Ok((offset_x, y))
             },
-            "center-right" => {
+            PositionType::Center => {
+                let x = ((canvas_width / 2) - (image_width / 2)) + offset_x;
+                let y = ((canvas_height / 2) - (image_height / 2)) + offset_y;
+                Ok((x, y))
+            },
+            PositionType::CenterRight => {
                 let x = (canvas_width - image_width) + offset_x;
                 let y = ((canvas_height / 2) - (image_height / 2)) + offset_y;
                 Ok((x, y))
             },
-            "bottom-left" => {
+            PositionType::BottomLeft => {
                 let y = (canvas_height - image_height) + offset_y;
                 Ok((offset_x, y))
             },
-            "bottom-center" => {
+            PositionType::BottomCenter => {
                 let x = ((canvas_width / 2) - (image_width / 2)) + offset_x;
                 let y = (canvas_height - image_height) + offset_y;
                 Ok((x, y))
             },
-            "bottom-right" => {
+            PositionType::BottomRight => {
                 let x = (canvas_width - image_width) + offset_y;
                 let y = (canvas_height - image_height) + offset_y;
                 Ok((x, y))
-            },
-            "center" => {
-                let x = ((canvas_width / 2) - (image_width / 2)) + offset_x;
-                let y = ((canvas_height / 2) - (image_height / 2)) + offset_y;
-                Ok((x, y))
-            },
-            _ => Err(RasterError::InvalidPositionType(self.position.to_string()))
+            }
         }
     }
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -12,6 +12,7 @@
 // from local crate
 use error::RasterResult;
 
+/// An enum for the various modes that can be used for positioning.
 #[derive(Debug)]
 pub enum PositionMode {
     TopLeft,

--- a/src/position.rs
+++ b/src/position.rs
@@ -13,7 +13,7 @@
 use error::RasterResult;
 
 #[derive(Debug)]
-pub enum PositionType {
+pub enum PositionMode {
     TopLeft,
     TopCenter,
     TopRight,
@@ -27,13 +27,13 @@ pub enum PositionType {
 
 /// Struct for computing position on an image.
 pub struct Position {
-    position: PositionType,
+    position: PositionMode,
     offset_x: i32,
     offset_y: i32
 }
 
 impl Position {
-    pub fn new(position: PositionType, offset_x: i32, offset_y: i32) -> Position {
+    pub fn new(position: PositionMode, offset_x: i32, offset_y: i32) -> Position {
         Position {
             position: position,
             offset_x: offset_x,
@@ -47,41 +47,41 @@ impl Position {
         let offset_y = self.offset_y;
 
         match self.position {
-            PositionType::TopLeft => {
+            PositionMode::TopLeft => {
                 Ok((offset_x, offset_y))
             },
-            PositionType::TopCenter => {
+            PositionMode::TopCenter => {
                 let x = ((canvas_width / 2) - (image_width / 2)) + offset_x;
                 Ok((x, offset_y))
             },
-            PositionType::TopRight => {
+            PositionMode::TopRight => {
                 let x = (canvas_width - image_width) + offset_x;
                 Ok((x, offset_y))
             },
-            PositionType::CenterLeft => {
+            PositionMode::CenterLeft => {
                 let y = ((canvas_height / 2) - (image_height / 2)) + offset_x;
                 Ok((offset_x, y))
             },
-            PositionType::Center => {
+            PositionMode::Center => {
                 let x = ((canvas_width / 2) - (image_width / 2)) + offset_x;
                 let y = ((canvas_height / 2) - (image_height / 2)) + offset_y;
                 Ok((x, y))
             },
-            PositionType::CenterRight => {
+            PositionMode::CenterRight => {
                 let x = (canvas_width - image_width) + offset_x;
                 let y = ((canvas_height / 2) - (image_height / 2)) + offset_y;
                 Ok((x, y))
             },
-            PositionType::BottomLeft => {
+            PositionMode::BottomLeft => {
                 let y = (canvas_height - image_height) + offset_y;
                 Ok((offset_x, y))
             },
-            PositionType::BottomCenter => {
+            PositionMode::BottomCenter => {
                 let x = ((canvas_width / 2) - (image_width / 2)) + offset_x;
                 let y = (canvas_height - image_height) + offset_y;
                 Ok((x, y))
             },
-            PositionType::BottomRight => {
+            PositionMode::BottomRight => {
                 let x = (canvas_width - image_width) + offset_y;
                 let y = (canvas_height - image_height) + offset_y;
                 Ok((x, y))

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -17,6 +17,7 @@ use interpolate::{resample, InterpolationMode};
 use position::PositionMode;
 use editor::crop;
 
+/// An enum for the various modes that can be used for transforming.
 #[derive(Debug)]
 pub enum TransformMode {
     /// Transform on x axis.

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -29,8 +29,8 @@ pub enum TransformMode {
 ///
 /// Mode:
 ///
-/// * X - Flip image horizontally.
-/// * Y - Flip image vertically.
+/// * `X` - Flip image horizontally.
+/// * `Y` - Flip image vertically.
 ///
 /// # Examples
 ///

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -14,7 +14,7 @@ use error::RasterResult;
 use Image;
 use Color;
 use interpolate::{resample, InterpolationMode};
-use position::PositionType;
+use position::PositionMode;
 use editor::crop;
 
 #[derive(Debug)]
@@ -267,7 +267,7 @@ pub fn resize_fill<'a>(mut src: &'a mut Image, w: i32, h: i32) -> RasterResult<(
     }
 
     try!(resample(&mut src, optimum_width, optimum_height, InterpolationMode::Bicubic));
-    try!(crop(&mut src, w, h, PositionType::Center, 0, 0)); // Trim excess parts
+    try!(crop(&mut src, w, h, PositionMode::Center, 0, 0)); // Trim excess parts
 
     Ok(())
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -19,18 +19,13 @@ use editor::crop;
 
 #[derive(Debug)]
 pub enum TransformMode {
-    /// Horizontal transform.
-    X,
-    /// Vertical transform.
-    Y
+    /// Transform on x axis.
+    Horizontal,
+    /// Transform on y axis.
+    Vertical
 }
 
 /// Flip an image on its x or y axis.
-///
-/// Mode:
-///
-/// * `X` - Flip image horizontally.
-/// * `Y` - Flip image vertically.
 ///
 /// # Examples
 ///
@@ -42,7 +37,7 @@ pub enum TransformMode {
 /// //...
 ///
 /// let mut image = raster::open("tests/in/sample.png").unwrap();
-/// transform::flip(&mut image, TransformMode::X).unwrap();
+/// transform::flip(&mut image, TransformMode::Horizontal).unwrap();
 /// raster::save(&image, "tests/out/test_transform_flip_x.png");
 /// ```
 ///
@@ -56,7 +51,7 @@ pub enum TransformMode {
 /// //...
 ///
 /// let mut image = raster::open("tests/in/sample.png").unwrap();
-/// transform::flip(&mut image, TransformMode::Y).unwrap();
+/// transform::flip(&mut image, TransformMode::Vertical).unwrap();
 /// raster::save(&image, "tests/out/test_transform_flip_y.png");
 /// ```
 ///
@@ -68,7 +63,7 @@ pub fn flip(mut src: &mut Image, mode: TransformMode ) -> RasterResult<()> {
     let h: i32 = src.height;
 
     match mode {
-        TransformMode::X => {
+        TransformMode::Horizontal => {
             for x in 0..w {
                 let src_x = x;
                 let dest_x = w - x - 1;
@@ -88,7 +83,7 @@ pub fn flip(mut src: &mut Image, mode: TransformMode ) -> RasterResult<()> {
 
             Ok(())
         },
-        TransformMode::Y => {
+        TransformMode::Vertical => {
             for y in 0..h {
                 let src_y = y;
                 let dest_y = h - y - 1;
@@ -121,8 +116,7 @@ pub fn flip(mut src: &mut Image, mode: TransformMode ) -> RasterResult<()> {
 /// ### Rotate 45 degrees with a black background color:
 ///
 /// ```
-/// use raster::transform;
-/// use raster::Color;
+/// use raster::{transform, Color};
 ///
 /// //...
 ///
@@ -137,8 +131,7 @@ pub fn flip(mut src: &mut Image, mode: TransformMode ) -> RasterResult<()> {
 /// ### Rotate 45 degrees counter-clockwise with a red background color:
 ///
 /// ```
-/// use raster::transform;
-/// use raster::Color;
+/// use raster::{transform, Color};
 ///
 /// //...
 ///


### PR DESCRIPTION
Closes #3 

This changes all functions that previously accepted a `&str` flag to instead accept an appropriate enum. There are various changes to note:

- For easy access, these enums are re-exported in the crate root, so anyone who wants to use `BlurMode` just has to `use raster::BlurMode;`.
- The transform modes were previously `"x"` and `"y"`, but I changed them to `Horizontal` and `Vertical`, as it's more explicit, expressive, and clear - and thus more rustic. For people with autocompletion, the loss of brevity is a non-issue, though I'd understand if you're not receptive to this change.
- In various places where the possible string flags were enumerated in the documentation, I removed them. Anyone who wants to know all variants just has to click on the enum type in the function signature, and additionally, the example sections showcase the possibilities. In situations where the modes were accompanied by descriptions, those descriptions are now present in the enum's documention, i.e. with `ResizeMode`. Still, I feel this change may be slightly controversial, which is why I feel the need to mention it here.
- I created a private `BlendFunction` enum that's just like the public `BlendMode` enum, except it doesn't have a `Normal` variant. `BlendFunction` was made specifically for consumption by `ch_alpha_f`, whereas `BlendMode` is part of the public API and used in all other places.