### PR TITLE
Light refactoring

### DIFF
--- a/src/compare.rs
+++ b/src/compare.rs
@@ -56,8 +56,7 @@ pub fn equal(image1: &Image, image2: &Image)-> RasterResult<bool> {
     // Check if image dimensions are equal
     if image1.width != image2.width || image1.height != image2.height {
 
-        return Ok(false);
-
+        Ok(false)
     } else {
 
         // Loop using image1
@@ -80,9 +79,9 @@ pub fn equal(image1: &Image, image2: &Image)-> RasterResult<bool> {
                 }
             }
         }
-    }
 
-    Ok(true)
+        Ok(true)
+    }
 }
 
 // Private functions

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -430,10 +430,10 @@ pub enum ResizeMode {
 ///
 pub fn resize(mut src: &mut Image, w: i32, h: i32, mode: ResizeMode) -> RasterResult<()> {
     match mode {
-        ResizeMode::Exact => transform::resize_exact(&mut src, w, h),
-        ResizeMode::ExactWidth => transform::resize_exact_width(&mut src, w),
-        ResizeMode::ExactHeight => transform::resize_exact_height(&mut src, h),
-        ResizeMode::Fit => transform::resize_fit(&mut src, w, h),
-        ResizeMode::Fill => transform::resize_fill(&mut src, w, h)
+        ResizeMode::Exact => transform::resize_exact(src, w, h),
+        ResizeMode::ExactWidth => transform::resize_exact_width(src, w),
+        ResizeMode::ExactHeight => transform::resize_exact_height(src, h),
+        ResizeMode::Fit => transform::resize_fit(src, w, h),
+        ResizeMode::Fill => transform::resize_fill(src, w, h)
     }
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -427,5 +427,5 @@ pub fn resize<'a>(mut src: &'a mut Image, w: i32, h: i32, mode: ResizeMode) -> R
         ResizeMode::ExactHeight => transform::resize_exact_height(&mut src, h),
         ResizeMode::Fit => transform::resize_fit(&mut src, w, h),
         ResizeMode::Fill => transform::resize_fill(&mut src, w, h)
-    }.map(|_| ())
+    }
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -85,7 +85,7 @@ use transform;
 ///
 /// ![](https://kosinix.github.io/raster/out/test_blend_screen.png)
 ///
-pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity: f32, position: PositionMode, offset_x: i32, offset_y: i32) -> RasterResult<Image> {
+pub fn blend(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity: f32, position: PositionMode, offset_x: i32, offset_y: i32) -> RasterResult<Image> {
 
     let mut opacity = opacity;
     if opacity > 1.0 {
@@ -228,7 +228,7 @@ pub fn blend<'a>(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity:
 /// ![](https://kosinix.github.io/raster/out/test_crop_bottom_center.jpg)
 /// ![](https://kosinix.github.io/raster/out/test_crop_bottom_right.jpg)
 ///
-pub fn crop<'a>(mut src: &'a mut Image, crop_width: i32, crop_height: i32, position: PositionMode, offset_x: i32, offset_y: i32) -> RasterResult<()> {
+pub fn crop(mut src: &mut Image, crop_width: i32, crop_height: i32, position: PositionMode, offset_x: i32, offset_y: i32) -> RasterResult<()> {
 
     // Turn into positioner struct
     let positioner = Position::new(position, offset_x, offset_y);
@@ -420,7 +420,7 @@ pub enum ResizeMode {
 ///
 /// ![](https://kosinix.github.io/raster/out/test_resize_exact_1.jpg) ![](https://kosinix.github.io/raster/out/test_resize_exact_2.jpg)
 ///
-pub fn resize<'a>(mut src: &'a mut Image, w: i32, h: i32, mode: ResizeMode) -> RasterResult<()> {
+pub fn resize(mut src: &mut Image, w: i32, h: i32, mode: ResizeMode) -> RasterResult<()> {
     match mode {
         ResizeMode::Exact => transform::resize_exact(&mut src, w, h),
         ResizeMode::ExactWidth => transform::resize_exact_width(&mut src, w),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -146,15 +146,15 @@ pub fn blend(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity: f32
 
     match blend_mode {
         BlendMode::Normal =>
-            blend::normal(&image1, &image2, loop_start_y, loop_end_y, loop_start_x, loop_end_x, offset_x, offset_y, opacity),
+            blend::normal(image1, image2, loop_start_y, loop_end_y, loop_start_x, loop_end_x, offset_x, offset_y, opacity),
         BlendMode::Difference =>
-            blend::difference(&image1, &image2, loop_start_y, loop_end_y, loop_start_x, loop_end_x, offset_x, offset_y, opacity),
+            blend::difference(image1, image2, loop_start_y, loop_end_y, loop_start_x, loop_end_x, offset_x, offset_y, opacity),
         BlendMode::Multiply =>
-            blend::multiply(&image1, &image2, loop_start_y, loop_end_y, loop_start_x, loop_end_x, offset_x, offset_y, opacity),
+            blend::multiply(image1, image2, loop_start_y, loop_end_y, loop_start_x, loop_end_x, offset_x, offset_y, opacity),
         BlendMode::Overlay =>
-            blend::overlay(&image1, &image2, loop_start_y, loop_end_y, loop_start_x, loop_end_x, offset_x, offset_y, opacity),
+            blend::overlay(image1, image2, loop_start_y, loop_end_y, loop_start_x, loop_end_x, offset_x, offset_y, opacity),
         BlendMode::Screen =>
-            blend::screen(&image1, &image2, loop_start_y, loop_end_y, loop_start_x, loop_end_x, offset_x, offset_y, opacity),
+            blend::screen(image1, image2, loop_start_y, loop_end_y, loop_start_x, loop_end_x, offset_x, offset_y, opacity),
     }
 }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -87,12 +87,13 @@ use transform;
 ///
 pub fn blend(image1: &Image, image2: &Image, blend_mode: BlendMode, opacity: f32, position: PositionMode, offset_x: i32, offset_y: i32) -> RasterResult<Image> {
 
-    let mut opacity = opacity;
-    if opacity > 1.0 {
-        opacity = 1.0
+    let opacity = if opacity > 1.0 {
+        1.0
     } else if opacity < 0.0 {
-        opacity = 0.0
-    }
+        0.0
+    } else {
+        opacity
+    };
 
     // Turn into positioner struct
     let positioner = Position::new(position, offset_x, offset_y);
@@ -237,16 +238,23 @@ pub fn crop(mut src: &mut Image, crop_width: i32, crop_height: i32, position: Po
     let offset_x = if offset_x < 0 { 0 } else { offset_x };
     let offset_y = if offset_y < 0 { 0 } else { offset_y };
 
+    let height2 = {
+        let height2 = offset_y + crop_height;
+        if height2 > src.height {
+            src.height
+        } else {
+            height2
+        }
+    };
 
-    let mut height2 = offset_y + crop_height;
-    if height2 > src.height {
-        height2 = src.height
-    }
-
-    let mut width2 = offset_x + crop_width;
-    if width2 > src.width {
-        width2 = src.width
-    }
+    let width2 = {
+        let width2 = offset_x + crop_width;
+        if width2 > src.width {
+            src.width
+        } else {
+            width2
+        }
+    };
 
     let mut dest = Image::blank(width2-offset_x, height2-offset_y);
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -60,7 +60,7 @@ pub fn blur<'a>(mut src: &'a mut Image, mode: BlurMode) -> RasterResult<()>{
     match mode {
         BlurMode::Box => blur_box(&mut src),
         BlurMode::Gaussian => blur_gaussian(&mut src)
-    }.map(|_| ())
+    }
 }
 
 /// Apply brightness.
@@ -237,9 +237,7 @@ pub fn emboss(mut src: &mut Image) -> RasterResult<()>{
         [0, 1, 2]
     ];
 
-    try!(convolve(&mut src, matrix, 1));
-
-    Ok(())
+    convolve(&mut src, matrix, 1)
 }
 
 /// Apply a gamma correction.
@@ -397,9 +395,7 @@ pub fn sharpen(mut src: &mut Image) -> RasterResult<()>{
         [0, -1, 0]
     ];
 
-    try!(convolve(&mut src, matrix, 1));
-
-    Ok(())
+    convolve(&mut src, matrix, 1)
 }
 
 
@@ -413,9 +409,7 @@ fn blur_box(mut src: &mut Image) -> RasterResult<()>{
         [1,1,1]
     ];
 
-    try!(convolve(&mut src, matrix, 9));
-
-    Ok(())
+    convolve(&mut src, matrix, 9)
 }
 
 // Gaussian
@@ -426,7 +420,5 @@ fn blur_gaussian(mut src: &mut Image) -> RasterResult<()>{
         [1,2,1]
     ];
 
-    try!(convolve(&mut src, matrix, 16));
-
-    Ok(())
+    convolve(&mut src, matrix, 16)
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -145,15 +145,14 @@ pub fn convolve(src: &mut Image, matrix: [[i32; 3]; 3], divisor: i32) -> RasterR
             let mut accum_blue: i32 = 0;
             let mut accum_alpha: i32 = 0;
 
-            let mut m_index_y = 0;
-            for mut src_y in mstarty..mstarty + m_size {
+            for (m_index_y, mut src_y) in (0..).zip(mstarty..mstarty + m_size) {
                 if src_y < 0 {
                     src_y = 0;
                 } else if src_y > h - 1 {
                     src_y = h - 1;
                 }
-                let mut m_index_x = 0;
-                for mut src_x in mstartx..mstartx + m_size {
+
+                for (m_index_x, mut src_x) in (0..).zip(mstartx..mstartx + m_size) {
                     if src_x < 0 {
                         src_x = 0;
                     } else if src_x > w - 1 {
@@ -165,10 +164,7 @@ pub fn convolve(src: &mut Image, matrix: [[i32; 3]; 3], divisor: i32) -> RasterR
                     accum_green += pixel.g as i32 * matrix[m_index_y][m_index_x];
                     accum_blue += pixel.b as i32 * matrix[m_index_y][m_index_x];
                     accum_alpha += pixel.a as i32 * matrix[m_index_y][m_index_x];
-
-                    m_index_x+=1;
                 }
-                m_index_y+=1;
             }
 
             if divisor != 1 {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -56,7 +56,7 @@ pub enum BlurMode {
 /// ### After
 /// ![](https://kosinix.github.io/raster/out/test_filter_gaussian_blur.jpg)
 ///
-pub fn blur<'a>(mut src: &'a mut Image, mode: BlurMode) -> RasterResult<()>{
+pub fn blur(mut src: &mut Image, mode: BlurMode) -> RasterResult<()>{
     match mode {
         BlurMode::Box => blur_box(&mut src),
         BlurMode::Gaussian => blur_gaussian(&mut src)

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -58,8 +58,8 @@ pub enum BlurMode {
 ///
 pub fn blur(mut src: &mut Image, mode: BlurMode) -> RasterResult<()>{
     match mode {
-        BlurMode::Box => blur_box(&mut src),
-        BlurMode::Gaussian => blur_gaussian(&mut src)
+        BlurMode::Box => blur_box(src),
+        BlurMode::Gaussian => blur_gaussian(src)
     }
 }
 
@@ -233,7 +233,7 @@ pub fn emboss(mut src: &mut Image) -> RasterResult<()>{
         [0, 1, 2]
     ];
 
-    convolve(&mut src, matrix, 1)
+    convolve(src, matrix, 1)
 }
 
 /// Apply a gamma correction.
@@ -391,7 +391,7 @@ pub fn sharpen(mut src: &mut Image) -> RasterResult<()>{
         [0, -1, 0]
     ];
 
-    convolve(&mut src, matrix, 1)
+    convolve(src, matrix, 1)
 }
 
 
@@ -405,7 +405,7 @@ fn blur_box(mut src: &mut Image) -> RasterResult<()>{
         [1,1,1]
     ];
 
-    convolve(&mut src, matrix, 9)
+    convolve(src, matrix, 9)
 }
 
 // Gaussian
@@ -416,5 +416,5 @@ fn blur_gaussian(mut src: &mut Image) -> RasterResult<()>{
         [1,2,1]
     ];
 
-    convolve(&mut src, matrix, 16)
+    convolve(src, matrix, 16)
 }

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -81,10 +81,14 @@ fn bilinear_width(mut src: &mut Image, w2: i32) -> RasterResult<()> {
     for y in 0..h1 {
         for x in x_start..x_end {
 
-            let mut src_x = x as f64 * x_ratio;
-            if src_x < 0.0 {
-                src_x = 0.0; // limit lower bound to 0
-            }
+            let src_x = {
+                let src_x = x as f64 * x_ratio;
+                if src_x < 0.0 {
+                    0.0 // limit lower bound to 0
+                } else {
+                    src_x
+                }
+            };
 
             let src_x_int = (src_x).floor() as i32;
 
@@ -137,11 +141,14 @@ fn bilinear_height(mut src: &mut Image, h2: i32) -> RasterResult<()> {
     for x in 0..w1 {
         for y in y_start..y_end {
 
-            let mut src_y = y as f64 * y_ratio;
-
-            if src_y < 0.0 {
-                src_y = 0.0; // limit lower bound to 0
-            }
+            let src_y = {
+                let src_y = y as f64 * y_ratio;
+                if src_y < 0.0 {
+                    0.0 // limit lower bound to 0
+                } else {
+                    src_y
+                }
+            };
 
             let src_y_int = (src_y).floor() as i32;
 

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -28,7 +28,7 @@ pub fn resample<'a>(mut src: &'a mut Image, w: i32, h: i32, interpolation: Inter
         InterpolationMode::Bilinear => bilinear(&mut src, w, h),
         InterpolationMode::Bicubic => bilinear(&mut src, w, h), // TODO: bicubic
         InterpolationMode::Nearest => nearest(&mut src, w, h)
-    }.map(|_| ())
+    }
 }
 
 /// Interpolate using nearest neighbor.
@@ -57,11 +57,8 @@ pub fn nearest<'a>(mut src: &'a mut Image, w: i32, h: i32) -> RasterResult<()> {
 
 /// Interpolate using linear function.
 pub fn bilinear<'a>(mut src: &'a mut Image, w2: i32, h2: i32) -> RasterResult<()> {
-
-    try!(bilinear_width(&mut src, w2));
-    try!(bilinear_height(&mut src, h2));
-
-    Ok(())
+    bilinear_width(&mut src, w2)
+        .and_then(|_| bilinear_height(&mut src, h2))
 }
 
 // Private functions

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -25,9 +25,9 @@ pub enum InterpolationMode {
 /// Resample an image into a new size using a given interpolation method.
 pub fn resample(mut src: &mut Image, w: i32, h: i32, interpolation: InterpolationMode) -> RasterResult<()> {
     match interpolation {
-        InterpolationMode::Bilinear => bilinear(&mut src, w, h),
-        InterpolationMode::Bicubic => bilinear(&mut src, w, h), // TODO: bicubic
-        InterpolationMode::Nearest => nearest(&mut src, w, h)
+        InterpolationMode::Bilinear => bilinear(src, w, h),
+        InterpolationMode::Bicubic => bilinear(src, w, h), // TODO: bicubic
+        InterpolationMode::Nearest => nearest(src, w, h)
     }
 }
 
@@ -57,8 +57,8 @@ pub fn nearest(mut src: &mut Image, w: i32, h: i32) -> RasterResult<()> {
 
 /// Interpolate using linear function.
 pub fn bilinear(mut src: &mut Image, w2: i32, h2: i32) -> RasterResult<()> {
-    bilinear_width(&mut src, w2)
-        .and_then(|_| bilinear_height(&mut src, h2))
+    bilinear_width(src, w2)
+        .and_then(|_| bilinear_height(src, h2))
 }
 
 // Private functions

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -23,7 +23,7 @@ pub enum InterpolationMode {
 }
 
 /// Resample an image into a new size using a given interpolation method.
-pub fn resample<'a>(mut src: &'a mut Image, w: i32, h: i32, interpolation: InterpolationMode) -> RasterResult<()> {
+pub fn resample(mut src: &mut Image, w: i32, h: i32, interpolation: InterpolationMode) -> RasterResult<()> {
     match interpolation {
         InterpolationMode::Bilinear => bilinear(&mut src, w, h),
         InterpolationMode::Bicubic => bilinear(&mut src, w, h), // TODO: bicubic
@@ -32,7 +32,7 @@ pub fn resample<'a>(mut src: &'a mut Image, w: i32, h: i32, interpolation: Inter
 }
 
 /// Interpolate using nearest neighbor.
-pub fn nearest<'a>(mut src: &'a mut Image, w: i32, h: i32) -> RasterResult<()> {
+pub fn nearest(mut src: &mut Image, w: i32, h: i32) -> RasterResult<()> {
 
     let x_ratio: f64 = src.width as f64 / w as f64;
     let y_ratio: f64 = src.height as f64 / h as f64;
@@ -56,7 +56,7 @@ pub fn nearest<'a>(mut src: &'a mut Image, w: i32, h: i32) -> RasterResult<()> {
 }
 
 /// Interpolate using linear function.
-pub fn bilinear<'a>(mut src: &'a mut Image, w2: i32, h2: i32) -> RasterResult<()> {
+pub fn bilinear(mut src: &mut Image, w2: i32, h2: i32) -> RasterResult<()> {
     bilinear_width(&mut src, w2)
         .and_then(|_| bilinear_height(&mut src, h2))
 }
@@ -64,7 +64,7 @@ pub fn bilinear<'a>(mut src: &'a mut Image, w2: i32, h2: i32) -> RasterResult<()
 // Private functions
 
 /// Interpolate the width using linear function.
-fn bilinear_width<'a>(mut src: &'a mut Image, w2: i32) -> RasterResult<()> {
+fn bilinear_width(mut src: &mut Image, w2: i32) -> RasterResult<()> {
 
     let w1 = src.width;
     let h1 = src.height;
@@ -120,7 +120,7 @@ fn bilinear_width<'a>(mut src: &'a mut Image, w2: i32) -> RasterResult<()> {
 }
 
 /// Interpolate the height using linear function.
-fn bilinear_height<'a>(mut src: &'a mut Image, h2: i32) -> RasterResult<()> {
+fn bilinear_height(mut src: &mut Image, h2: i32) -> RasterResult<()> {
 
     let w1 = src.width;
     let h1 = src.height;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,14 +540,14 @@ impl<'a> Color {
     /// assert_eq!(255, color.g);
     /// ```
     pub fn hex(hex: &str) -> RasterResult<Color> {
-        if hex.len() == 9 && hex.starts_with("#") { // #FFFFFFFF (Red Green Blue Alpha)
+        if hex.len() == 9 && hex.starts_with('#') { // #FFFFFFFF (Red Green Blue Alpha)
             Ok(Color {
                 r: try!(_hex_dec(&hex[1..3])),
                 g: try!(_hex_dec(&hex[3..5])),
                 b: try!(_hex_dec(&hex[5..7])),
                 a: try!(_hex_dec(&hex[7..9])),
             })
-        } else if hex.len() == 7 && hex.starts_with("#") { // #FFFFFF (Red Green Blue)
+        } else if hex.len() == 7 && hex.starts_with('#') { // #FFFFFF (Red Green Blue)
             Ok(Color {
                 r: try!(_hex_dec(&hex[1..3])),
                 g: try!(_hex_dec(&hex[3..5])),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,7 +416,33 @@ impl<'a> Image {
     }
 }
 
+fn rgb_min(r: f32, g: f32, b: f32) -> f32 {
+    let min = if g < r {
+        g
+    } else {
+        r
+    };
 
+    if b < min {
+        b
+    } else {
+        min
+    }
+}
+
+fn rgb_max(r: f32, g: f32, b: f32) -> f32 {
+    let max = if g > r {
+        g
+    } else {
+        r
+    };
+
+    if b > max {
+        b
+    } else {
+        max
+    }
+}
 
 /// A struct for representing and creating color.
 #[derive(Debug, Clone)]
@@ -605,44 +631,34 @@ impl<'a> Color {
         let g = g as f32 / 255.0;
         let b = b as f32 / 255.0;
 
-        let mut min = r;
-        if g < min {
-            min = g;
-        }
-        if b < min {
-            min = b;
-        }
-
-        let mut max = r;
-        if g > max {
-            max = g;
-        }
-        if b > max {
-            max = b;
-        }
-
+        let min = rgb_min(r, g, b);
+        let max = rgb_max(r, g, b);
 
         let chroma = max - min;
-        let mut h = 0.0;
 
-        if chroma != 0.0 {
+        let h = {
+            let mut h = 0.0;
 
-            if max == r {
-                h = 60.0 * ((g - b) / chroma);
-                if h < 0.0 {
-                    h += 360.0;
+            if chroma != 0.0 {
+                if max == r {
+                    h = 60.0 * ((g - b) / chroma);
+                    if h < 0.0 {
+                        h += 360.0;
+                    }
+                } else if max == g {
+                    h = 60.0 * (((b - r) / chroma) + 2.0);
+                } else if max == b {
+                    h = 60.0 * (((r - g) / chroma) + 4.0);
                 }
-            } else if max == g {
-                h = 60.0 * (((b - r) / chroma) + 2.0);
-            } else if max == b {
-                h = 60.0 * (((r - g) / chroma) + 4.0);
             }
 
-        }
+            if h > 359.0 {
+                h = 360.0 - h; // Invert if > 0 to 359
+            }
 
-        if h > 359.0 {
-            h = 360.0 - h; // Invert if > 0 to 359
-        }
+            h
+        };
+
         let v = max;
         let s = if v != 0.0 {
             chroma / v

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,8 @@ pub use interpolate::InterpolationMode;
 pub use position::PositionMode;
 pub use transform::TransformMode;
 
+pub type Histogram = (HashMap<u8, u32>, HashMap<u8, u32>, HashMap<u8, u32>, HashMap<u8, u32>);
+
 /// Create an image from an image file.
 ///
 /// # Errors
@@ -317,7 +319,7 @@ impl<'a> Image {
     ///
     /// ![](https://kosinix.github.io/raster/in/histogram-ps.png)
     ///
-    pub fn histogram(&self) -> RasterResult<(HashMap<u8, u32>, HashMap<u8, u32>, HashMap<u8, u32>, HashMap<u8, u32>)> {
+    pub fn histogram(&self) -> RasterResult<Histogram> {
         let w = self.width;
         let h = self.height;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ pub fn save(image: &Image, out: &str) -> RasterResult<()> {
 }
 
 /// A struct for easily representing a raster image.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Image {
     /// Width of image in pixels.
     pub width: i32, //  i32 type is used as computation with negative integers is common.
@@ -236,24 +236,6 @@ impl<'a> Image {
             false
         } else {
             true
-        }
-    }
-
-    /// Create a clone of an image as another image.
-    ///
-    /// # Examples
-    /// ```
-    /// // Create image from file
-    /// let original = raster::open("tests/in/sample.jpg").unwrap();
-    ///
-    /// // Clone it
-    /// let clone = original.clone();
-    /// ```
-    pub fn clone(&self) -> Image {
-        Image{
-            width: self.width,
-            height: self.height,
-            bytes: self.bytes.clone(),
         }
     }
 
@@ -439,7 +421,7 @@ impl<'a> Image {
 
 
 /// A struct for representing and creating color.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Color {
     /// Red channel 0 - 255
     pub r: u8,
@@ -473,16 +455,6 @@ impl<'a> Color {
             g: 0,
             b: 255,
             a: 255,
-        }
-    }
-
-    /// Clones a Color.
-    pub fn clone(&self) -> Color {
-        Color {
-            r: self.r,
-            g: self.g,
-            b: self.b,
-            a: self.a,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,15 +230,13 @@ impl<'a> Image {
     /// assert_eq!(image.check_pixel(3, 3), false);
     /// ```
     pub fn check_pixel(&self, x: i32, y:i32) -> bool {
-
         if y < 0 || y > self.height { // TODO: check on actual vectors and not just width and height?
-            return false;
-
+            false
         } else if x < 0 || x > self.width {
-            return false;
+            false
+        } else {
+            true
         }
-
-        true
     }
 
     /// Create a clone of an image as another image.
@@ -676,11 +674,11 @@ impl<'a> Color {
             h = 360.0 - h; // Invert if > 0 to 359
         }
         let v = max;
-        let mut s = 0.0;
-        if v != 0.0 {
-
-            s = chroma / v;
-        }
+        let s = if v != 0.0 {
+            chroma / v
+        } else {
+            0.0
+        };
 
         ( h.round() as u16, s * 100.0, v * 100.0  )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,10 +232,8 @@ impl<'a> Image {
     pub fn check_pixel(&self, x: i32, y:i32) -> bool {
         if y < 0 || y > self.height { // TODO: check on actual vectors and not just width and height?
             false
-        } else if x < 0 || x > self.width {
-            false
         } else {
-            true
+            !(x < 0 || x > self.width)
         }
     }
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -43,50 +43,49 @@ impl Position {
     }
 
     /// Get X and Y position based on parameters.
+    // Will this ever fail?
     pub fn get_x_y(&self, canvas_width: i32, canvas_height: i32, image_width:i32, image_height:i32) -> RasterResult<(i32, i32)> {
         let offset_x = self.offset_x;
         let offset_y = self.offset_y;
 
-        match self.position {
-            PositionMode::TopLeft => {
-                Ok((offset_x, offset_y))
-            },
+        Ok(match self.position {
+            PositionMode::TopLeft => (offset_x, offset_y),
             PositionMode::TopCenter => {
                 let x = ((canvas_width / 2) - (image_width / 2)) + offset_x;
-                Ok((x, offset_y))
+                (x, offset_y)
             },
             PositionMode::TopRight => {
                 let x = (canvas_width - image_width) + offset_x;
-                Ok((x, offset_y))
+                (x, offset_y)
             },
             PositionMode::CenterLeft => {
                 let y = ((canvas_height / 2) - (image_height / 2)) + offset_x;
-                Ok((offset_x, y))
+                (offset_x, y)
             },
             PositionMode::Center => {
                 let x = ((canvas_width / 2) - (image_width / 2)) + offset_x;
                 let y = ((canvas_height / 2) - (image_height / 2)) + offset_y;
-                Ok((x, y))
+                (x, y)
             },
             PositionMode::CenterRight => {
                 let x = (canvas_width - image_width) + offset_x;
                 let y = ((canvas_height / 2) - (image_height / 2)) + offset_y;
-                Ok((x, y))
+                (x, y)
             },
             PositionMode::BottomLeft => {
                 let y = (canvas_height - image_height) + offset_y;
-                Ok((offset_x, y))
+                (offset_x, y)
             },
             PositionMode::BottomCenter => {
                 let x = ((canvas_width / 2) - (image_width / 2)) + offset_x;
                 let y = (canvas_height - image_height) + offset_y;
-                Ok((x, y))
+                (x, y)
             },
             PositionMode::BottomRight => {
                 let x = (canvas_width - image_width) + offset_y;
                 let y = (canvas_height - image_height) + offset_y;
-                Ok((x, y))
+                (x, y)
             }
-        }
+        })
     }
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -204,7 +204,7 @@ pub fn rotate(mut src: &mut Image, degree: i32, bg: Color) -> RasterResult<()>{
 /// Resize image to exact dimensions ignoring aspect ratio.
 /// Useful if you want to force exact width and height.
 pub fn resize_exact(mut src: &mut Image, w: i32, h: i32) -> RasterResult<()> {
-    resample(&mut src, w, h, InterpolationMode::Bicubic)
+    resample(src, w, h, InterpolationMode::Bicubic)
 }
 
 /// Resize image to exact height. Width is auto calculated.
@@ -218,7 +218,7 @@ pub fn resize_exact_height(mut src: &mut Image, h: i32) -> RasterResult<()> {
     let resize_height = h;
     let resize_width = (h as f32 * ratio) as i32;
 
-    resample(&mut src, resize_width, resize_height, InterpolationMode::Bicubic)
+    resample(src, resize_width, resize_height, InterpolationMode::Bicubic)
 }
 
 /// Resize image to exact width. Height is auto calculated.
@@ -231,7 +231,7 @@ pub fn resize_exact_width(mut src: &mut Image, w: i32) -> RasterResult<()> {
     let resize_width  = w;
     let resize_height = (w as f32 / ratio).round() as i32;
 
-    resample(&mut src, resize_width, resize_height, InterpolationMode::Bicubic)
+    resample(src, resize_width, resize_height, InterpolationMode::Bicubic)
 }
 
 /// Resize image to fill all the space in the given dimension. Excess parts are removed.
@@ -250,8 +250,8 @@ pub fn resize_fill(mut src: &mut Image, w: i32, h: i32) -> RasterResult<()> {
         optimum_height = h;
     }
 
-    resample(&mut src, optimum_width, optimum_height, InterpolationMode::Bicubic)
-        .and_then(|_| crop(&mut src, w, h, PositionMode::Center, 0, 0)) // Trim excess parts
+    resample(src, optimum_width, optimum_height, InterpolationMode::Bicubic)
+        .and_then(|_| crop(src, w, h, PositionMode::Center, 0, 0)) // Trim excess parts
 }
 
 /// Resize an image to fit within the given width and height.
@@ -271,7 +271,7 @@ pub fn resize_fit(mut src: &mut Image, w: i32, h: i32) -> RasterResult<()> {
         resize_width  = (h as f64 * ratio).round() as i32;
     }
 
-    resample(&mut src, resize_width, resize_height, InterpolationMode::Bicubic)
+    resample(src, resize_width, resize_height, InterpolationMode::Bicubic)
 }
 
 // Private functions

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -210,9 +210,7 @@ pub fn rotate(mut src: &mut Image, degree: i32, bg: Color) -> RasterResult<()>{
 /// Resize image to exact dimensions ignoring aspect ratio.
 /// Useful if you want to force exact width and height.
 pub fn resize_exact<'a>(mut src: &'a mut Image, w: i32, h: i32) -> RasterResult<()> {
-
-    try!(resample(&mut src, w, h, InterpolationMode::Bicubic));
-    Ok(())
+    resample(&mut src, w, h, InterpolationMode::Bicubic)
 }
 
 /// Resize image to exact height. Width is auto calculated.
@@ -226,8 +224,7 @@ pub fn resize_exact_height<'a>(mut src: &'a mut Image, h: i32) -> RasterResult<(
     let resize_height = h;
     let resize_width = (h as f32 * ratio) as i32;
 
-    try!(resample(&mut src, resize_width, resize_height, InterpolationMode::Bicubic));
-    Ok(())
+    resample(&mut src, resize_width, resize_height, InterpolationMode::Bicubic)
 }
 
 /// Resize image to exact width. Height is auto calculated.
@@ -240,8 +237,7 @@ pub fn resize_exact_width<'a>(mut src: &'a mut Image, w: i32) -> RasterResult<()
     let resize_width  = w;
     let resize_height = (w as f32 / ratio).round() as i32;
 
-    try!(resample(&mut src, resize_width, resize_height, InterpolationMode::Bicubic));
-    Ok(())
+    resample(&mut src, resize_width, resize_height, InterpolationMode::Bicubic)
 }
 
 /// Resize image to fill all the space in the given dimension. Excess parts are removed.
@@ -260,10 +256,8 @@ pub fn resize_fill<'a>(mut src: &'a mut Image, w: i32, h: i32) -> RasterResult<(
         optimum_height = h;
     }
 
-    try!(resample(&mut src, optimum_width, optimum_height, InterpolationMode::Bicubic));
-    try!(crop(&mut src, w, h, PositionMode::Center, 0, 0)); // Trim excess parts
-
-    Ok(())
+    resample(&mut src, optimum_width, optimum_height, InterpolationMode::Bicubic)
+        .and_then(|_| crop(&mut src, w, h, PositionMode::Center, 0, 0)) // Trim excess parts
 }
 
 /// Resize an image to fit within the given width and height.
@@ -283,8 +277,7 @@ pub fn resize_fit<'a>(mut src: &'a mut Image, w: i32, h: i32) -> RasterResult<()
         resize_width  = (h as f64 * ratio).round() as i32;
     }
 
-    try!(resample(&mut src, resize_width, resize_height, InterpolationMode::Bicubic));
-    Ok(())
+    resample(&mut src, resize_width, resize_height, InterpolationMode::Bicubic)
 }
 
 // Private functions

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -209,13 +209,13 @@ pub fn rotate(mut src: &mut Image, degree: i32, bg: Color) -> RasterResult<()>{
 
 /// Resize image to exact dimensions ignoring aspect ratio.
 /// Useful if you want to force exact width and height.
-pub fn resize_exact<'a>(mut src: &'a mut Image, w: i32, h: i32) -> RasterResult<()> {
+pub fn resize_exact(mut src: &mut Image, w: i32, h: i32) -> RasterResult<()> {
     resample(&mut src, w, h, InterpolationMode::Bicubic)
 }
 
 /// Resize image to exact height. Width is auto calculated.
 /// Useful for creating row of images with the same height.
-pub fn resize_exact_height<'a>(mut src: &'a mut Image, h: i32) -> RasterResult<()> {
+pub fn resize_exact_height(mut src: &mut Image, h: i32) -> RasterResult<()> {
 
     let width = src.width;
     let height = src.height;
@@ -229,7 +229,7 @@ pub fn resize_exact_height<'a>(mut src: &'a mut Image, h: i32) -> RasterResult<(
 
 /// Resize image to exact width. Height is auto calculated.
 /// Useful for creating column of images with the same width.
-pub fn resize_exact_width<'a>(mut src: &'a mut Image, w: i32) -> RasterResult<()> {
+pub fn resize_exact_width(mut src: &mut Image, w: i32) -> RasterResult<()> {
     let width  = src.width;
     let height = src.height;
     let ratio  = width as f32 / height as f32;
@@ -241,7 +241,7 @@ pub fn resize_exact_width<'a>(mut src: &'a mut Image, w: i32) -> RasterResult<()
 }
 
 /// Resize image to fill all the space in the given dimension. Excess parts are removed.
-pub fn resize_fill<'a>(mut src: &'a mut Image, w: i32, h: i32) -> RasterResult<()> {
+pub fn resize_fill(mut src: &mut Image, w: i32, h: i32) -> RasterResult<()> {
     let width  = src.width;
     let height = src.height;
     let ratio  = width as f32 / height as f32;
@@ -263,7 +263,7 @@ pub fn resize_fill<'a>(mut src: &'a mut Image, w: i32, h: i32) -> RasterResult<(
 /// Resize an image to fit within the given width and height.
 /// The re-sized image will not exceed the given dimension.
 /// Preserves the aspect ratio.
-pub fn resize_fit<'a>(mut src: &'a mut Image, w: i32, h: i32) -> RasterResult<()> {
+pub fn resize_fit(mut src: &mut Image, w: i32, h: i32) -> RasterResult<()> {
 
     let ratio: f64 = src.width as f64 / src.height as f64;
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -181,11 +181,8 @@ pub fn rotate(mut src: &mut Image, degree: i32, bg: Color) -> RasterResult<()>{
     let h2 = ((min_y as f32).abs() + (max_y as f32).abs()) as i32 + 1;
     let mut dest = Image::blank(w2, h2);
 
-    let mut dest_y = 0;
-    for y in min_y..max_y+1 {
-
-        let mut dest_x = 0;
-        for x in min_x..max_x+1{
+    for (dest_y, y) in (0..).zip(min_y..max_y + 1) {
+        for (dest_x, x) in (0..).zip(min_x..max_x + 1) {
             let point: (i32, i32) = _rotate((x,y), -degree);
 
             if point.0 >= 0 && point.0 < w1 && point.1 >=0 && point.1 < h1 {
@@ -194,10 +191,7 @@ pub fn rotate(mut src: &mut Image, degree: i32, bg: Color) -> RasterResult<()>{
             } else {
                 try!(dest.set_pixel(dest_x, dest_y, Color::rgba(bg.r, bg.g, bg.b, bg.a)));
             }
-            dest_x += 1;
-
         }
-        dest_y += 1;
     }
 
     src.width = dest.width;


### PR DESCRIPTION
This pull request makes some code more idiomatic, or otherwise more clear. There are no API changes, unless you count the `Histogram` type alias. Many of these changes were made at the suggestion of [clippy](https://github.com/Manishearth/rust-clippy). Hopefully most of my commit messages speak for themselves, but I will explain some of the changes that I feel are less self-explanatory.

- A bunch of functions ended with a pattern like `try!(some_function());` followed by `Ok(())`. That's equivalent to simply doing `some_function()`, as the function being called had a return type of `RasterResult<()>`.
- In various places, mutable variables were created, mutated immediately, then were never mutated again. This means that anyone reading the code will have to scan through the remainder of the scope to see if the variable is mutated later. Thanks to expression blocks, we can do these "immediate mutations" in an isolated scope, and then use the return of that to set an immutable variable. This way, it's easier to comprehend state changes in a function, as the mutability has been minimized to only what's necessary.
- I previously used `map(|_| ())` in a few places, as I hadn't realized that I'd been using it on functions that already had a return type of `RasterResult<()>`! I feel mildly silly.