### PR TITLE
Commit tests/out directory to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 target
 Cargo.lock
-tests/out/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ matrix:
     - rust: nightly
 
 before_script:
-  - sudo mkdir -p /home/travis/build/kosinix/raster/tests/out
   - sudo chmod -R 0777 /home/travis/build/kosinix/raster/tests/

--- a/tests/out/.gitignore
+++ b/tests/out/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
The test suite will fail if the out folder does not exist.
This change makes it easier for a new contributor to clone the project
and see the tests run and pass.

Any files produced by tests into the tests/out directory
will still be ignored, but the directory itself will exist.