### PR TITLE
Exciting 2018 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,10 @@
 language: rust
 cache: cargo
 rust:
-  - stable
+  - nightly
   - beta
-matrix:
-  include:
-    - rust: nightly
-      env: RUSTFMT=0.3.1
-      install:
-        - export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH
-        - if [[ `rustfmt --version` != $RUSTFMT* ]] ; then travis_wait cargo install --force rustfmt-nightly --vers $RUSTFMT; fi
-        - export PATH="$PATH:$HOME/.cargo/bin"
-      script:
-        - rustfmt --write-mode=diff src/lib.rs
-        - cargo build
-        - cargo test
+  - stable
+  - 1.24.1
 before_script:
   - sudo chmod -R 0777 /home/travis/build/kosinix/raster/tests/
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,8 @@ script:
   - cargo test
   - cargo doc
 after_success:
-  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash deploy-docs.sh
+  - |
+    [ $TRAVIS_BRANCH = master ] &&
+    [ $TRAVIS_PULL_REQUEST = false ] &&
+    bash deploy-docs.sh &&
+    cargo publish --token ${CRATESIO_TOKEN}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Change Log
+# Unreleased
 
-## Unreleased
-
-- Added Sobel edge detection. ([#15](https://github.com/kosinix/raster/pull/15))
+- Added Sobel edge detection ([#15](https://github.com/kosinix/raster/pull/15))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ homepage = "https://github.com/kosinix/raster"
 repository = "https://github.com/kosinix/raster.git"
 
 [dependencies.image]
-version = "0.17"
+version = "0.19"
 default-features = false
-features = ["jpeg"]
+features = ["jpeg", "jpeg_rayon"]
 
 [dependencies.gif]
-version = "0.9"
+version = "0.10"
 
 [dependencies.png]
-version = "0.11"
+version = "0.12"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016-2017 Nico Amarilla
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -7,8 +7,8 @@ set -o errexit -o nounset
 rev=$(git rev-parse --short HEAD)
 
 git init
-git config user.name "Francesca Sunshine"
-git config user.email "francesca@comfy.love"
+git config user.name "Francesca Frangipane"
+git config user.email "francesca@comfysoft.net"
 
 git remote add upstream "https://$GH_TOKEN@github.com/kosinix/raster.git"
 git fetch upstream

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,0 @@
-use_try_shorthand = true
-
-# This was merged, but doesn't seem to work? https://github.com/rust-lang-nursery/rustfmt/pull/1869
-# error_on_line_overflow_comments = false
-error_on_line_overflow = false


### PR DESCRIPTION
- Test nightly, beta, stable, and 1.24.1 on Travis
- Don't enforce `rustfmt`, since that doesn't necessarily generate good output
- Added a `LICENSE` file, since it was missing
- Updated dependencies, including opting into the multithreaded JPEG decoding feature
- Poached auto-publish from winit's Travis config